### PR TITLE
feat(create): add next support for create

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
             "dependencies": {
                 "@swc/helpers": "~0.4.11",
                 "chalk": "4.1.0",
+                "change-case": "^4.1.2",
                 "enquirer": "^2.3.6",
                 "semver": "^7.3.8",
                 "tslib": "^2.3.0",
@@ -6783,6 +6784,15 @@
                 "node": ">=6"
             }
         },
+        "node_modules/camel-case": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+            "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+            "dependencies": {
+                "pascal-case": "^3.1.2",
+                "tslib": "^2.0.3"
+            }
+        },
         "node_modules/camelcase": {
             "version": "5.3.1",
             "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
@@ -6834,6 +6844,16 @@
                 }
             ]
         },
+        "node_modules/capital-case": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
+            "integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
+            "dependencies": {
+                "no-case": "^3.0.4",
+                "tslib": "^2.0.3",
+                "upper-case-first": "^2.0.2"
+            }
+        },
         "node_modules/caseless": {
             "version": "0.12.0",
             "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
@@ -6851,6 +6871,25 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/change-case": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+            "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+            "dependencies": {
+                "camel-case": "^4.1.2",
+                "capital-case": "^1.0.4",
+                "constant-case": "^3.0.4",
+                "dot-case": "^3.0.4",
+                "header-case": "^2.0.4",
+                "no-case": "^3.0.4",
+                "param-case": "^3.0.4",
+                "pascal-case": "^3.1.2",
+                "path-case": "^3.0.4",
+                "sentence-case": "^3.0.4",
+                "snake-case": "^3.0.4",
+                "tslib": "^2.0.3"
             }
         },
         "node_modules/char-regex": {
@@ -7334,6 +7373,16 @@
             "dev": true,
             "engines": {
                 "node": ">=0.8"
+            }
+        },
+        "node_modules/constant-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
+            "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+            "dependencies": {
+                "no-case": "^3.0.4",
+                "tslib": "^2.0.3",
+                "upper-case": "^2.0.2"
             }
         },
         "node_modules/content-disposition": {
@@ -8641,6 +8690,15 @@
             },
             "funding": {
                 "url": "https://github.com/fb55/domutils?sponsor=1"
+            }
+        },
+        "node_modules/dot-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+            "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+            "dependencies": {
+                "no-case": "^3.0.4",
+                "tslib": "^2.0.3"
             }
         },
         "node_modules/dotenv": {
@@ -11301,6 +11359,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/header-case": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
+            "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
+            "dependencies": {
+                "capital-case": "^1.0.4",
+                "tslib": "^2.0.3"
             }
         },
         "node_modules/homedir-polyfill": {
@@ -14107,6 +14174,14 @@
                 "node": ">=4"
             }
         },
+        "node_modules/lower-case": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+            "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+            "dependencies": {
+                "tslib": "^2.0.3"
+            }
+        },
         "node_modules/lru-cache": {
             "version": "6.0.0",
             "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
@@ -14835,6 +14910,15 @@
                 "node": ">=10"
             }
         },
+        "node_modules/no-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+            "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+            "dependencies": {
+                "lower-case": "^2.0.2",
+                "tslib": "^2.0.3"
+            }
+        },
         "node_modules/node-abort-controller": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.0.1.tgz",
@@ -15344,6 +15428,15 @@
                 "node": ">=6"
             }
         },
+        "node_modules/param-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+            "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+            "dependencies": {
+                "dot-case": "^3.0.4",
+                "tslib": "^2.0.3"
+            }
+        },
         "node_modules/parent-module": {
             "version": "1.0.1",
             "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
@@ -15420,11 +15513,29 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/pascal-case": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+            "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+            "dependencies": {
+                "no-case": "^3.0.4",
+                "tslib": "^2.0.3"
+            }
+        },
         "node_modules/path-browserify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
             "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
             "dev": true
+        },
+        "node_modules/path-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
+            "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
+            "dependencies": {
+                "dot-case": "^3.0.4",
+                "tslib": "^2.0.3"
+            }
         },
         "node_modules/path-exists": {
             "version": "4.0.0",
@@ -17299,6 +17410,16 @@
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "dev": true
         },
+        "node_modules/sentence-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
+            "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
+            "dependencies": {
+                "no-case": "^3.0.4",
+                "tslib": "^2.0.3",
+                "upper-case-first": "^2.0.2"
+            }
+        },
         "node_modules/serialize-javascript": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
@@ -17456,6 +17577,15 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/snake-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+            "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+            "dependencies": {
+                "dot-case": "^3.0.4",
+                "tslib": "^2.0.3"
             }
         },
         "node_modules/sockjs": {
@@ -18829,6 +18959,22 @@
             },
             "peerDependencies": {
                 "browserslist": ">= 4.21.0"
+            }
+        },
+        "node_modules/upper-case": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
+            "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
+            "dependencies": {
+                "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/upper-case-first": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
+            "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
+            "dependencies": {
+                "tslib": "^2.0.3"
             }
         },
         "node_modules/uri-js": {
@@ -24637,6 +24783,15 @@
             "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
             "dev": true
         },
+        "camel-case": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+            "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+            "requires": {
+                "pascal-case": "^3.1.2",
+                "tslib": "^2.0.3"
+            }
+        },
         "camelcase": {
             "version": "5.3.1",
             "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
@@ -24669,6 +24824,16 @@
             "integrity": "sha512-aOBHrLmTQw//WFa2rcF1If9fa3ypkC1wzqqiKHgfdrXTWcU8C4gKVZT77eQAPWN1APys3+uQ0Df07rKauXGEYA==",
             "dev": true
         },
+        "capital-case": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
+            "integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
+            "requires": {
+                "no-case": "^3.0.4",
+                "tslib": "^2.0.3",
+                "upper-case-first": "^2.0.2"
+            }
+        },
         "caseless": {
             "version": "0.12.0",
             "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
@@ -24680,6 +24845,25 @@
             "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
+            }
+        },
+        "change-case": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+            "integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+            "requires": {
+                "camel-case": "^4.1.2",
+                "capital-case": "^1.0.4",
+                "constant-case": "^3.0.4",
+                "dot-case": "^3.0.4",
+                "header-case": "^2.0.4",
+                "no-case": "^3.0.4",
+                "param-case": "^3.0.4",
+                "pascal-case": "^3.1.2",
+                "path-case": "^3.0.4",
+                "sentence-case": "^3.0.4",
+                "snake-case": "^3.0.4",
+                "tslib": "^2.0.3"
             }
         },
         "char-regex": {
@@ -25057,6 +25241,16 @@
             "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz",
             "integrity": "sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==",
             "dev": true
+        },
+        "constant-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
+            "integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+            "requires": {
+                "no-case": "^3.0.4",
+                "tslib": "^2.0.3",
+                "upper-case": "^2.0.2"
+            }
         },
         "content-disposition": {
             "version": "0.5.4",
@@ -25994,6 +26188,15 @@
                 "dom-serializer": "^1.0.1",
                 "domelementtype": "^2.2.0",
                 "domhandler": "^4.2.0"
+            }
+        },
+        "dot-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+            "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+            "requires": {
+                "no-case": "^3.0.4",
+                "tslib": "^2.0.3"
             }
         },
         "dotenv": {
@@ -28005,6 +28208,15 @@
             "dev": true,
             "requires": {
                 "has-symbols": "^1.0.2"
+            }
+        },
+        "header-case": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
+            "integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
+            "requires": {
+                "capital-case": "^1.0.4",
+                "tslib": "^2.0.3"
             }
         },
         "homedir-polyfill": {
@@ -30117,6 +30329,14 @@
                 }
             }
         },
+        "lower-case": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+            "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+            "requires": {
+                "tslib": "^2.0.3"
+            }
+        },
         "lru-cache": {
             "version": "6.0.0",
             "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
@@ -30649,6 +30869,15 @@
                 }
             }
         },
+        "no-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+            "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+            "requires": {
+                "lower-case": "^2.0.2",
+                "tslib": "^2.0.3"
+            }
+        },
         "node-abort-controller": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.0.1.tgz",
@@ -31009,6 +31238,15 @@
             "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
             "dev": true
         },
+        "param-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+            "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+            "requires": {
+                "dot-case": "^3.0.4",
+                "tslib": "^2.0.3"
+            }
+        },
         "parent-module": {
             "version": "1.0.1",
             "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
@@ -31067,11 +31305,29 @@
             "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
             "dev": true
         },
+        "pascal-case": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+            "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+            "requires": {
+                "no-case": "^3.0.4",
+                "tslib": "^2.0.3"
+            }
+        },
         "path-browserify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
             "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
             "dev": true
+        },
+        "path-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
+            "integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
+            "requires": {
+                "dot-case": "^3.0.4",
+                "tslib": "^2.0.3"
+            }
         },
         "path-exists": {
             "version": "4.0.0",
@@ -32375,6 +32631,16 @@
                 }
             }
         },
+        "sentence-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
+            "integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
+            "requires": {
+                "no-case": "^3.0.4",
+                "tslib": "^2.0.3",
+                "upper-case-first": "^2.0.2"
+            }
+        },
         "serialize-javascript": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
@@ -32508,6 +32774,15 @@
             "version": "3.0.0",
             "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
             "dev": true
+        },
+        "snake-case": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+            "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+            "requires": {
+                "dot-case": "^3.0.4",
+                "tslib": "^2.0.3"
+            }
         },
         "sockjs": {
             "version": "0.3.24",
@@ -33498,6 +33773,22 @@
             "requires": {
                 "escalade": "^3.1.1",
                 "picocolors": "^1.0.0"
+            }
+        },
+        "upper-case": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
+            "integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
+            "requires": {
+                "tslib": "^2.0.3"
+            }
+        },
+        "upper-case-first": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
+            "integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
+            "requires": {
+                "tslib": "^2.0.3"
             }
         },
         "uri-js": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "dependencies": {
         "@swc/helpers": "~0.4.11",
         "chalk": "4.1.0",
+        "change-case": "^4.1.2",
         "enquirer": "^2.3.6",
         "semver": "^7.3.8",
         "tslib": "^2.3.0",

--- a/packages/create/bin/create-stacks-workspace.ts
+++ b/packages/create/bin/create-stacks-workspace.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import chalk from 'chalk';
+import { paramCase } from 'change-case';
 import { spawnSync } from 'child_process';
 import enquirer from 'enquirer';
 import path from 'path';
@@ -133,11 +134,9 @@ async function getConfiguration(argv: yargs.Arguments<CreateStacksArguments>) {
     }
 
     Object.assign(argv, {
-        name,
+        name: paramCase(name),
         preset,
-        appName,
-        nxVersion: '',
-        packageManager: '',
+        appName: paramCase(appName),
     });
 }
 

--- a/packages/create/bin/create-stacks-workspace.ts
+++ b/packages/create/bin/create-stacks-workspace.ts
@@ -12,9 +12,35 @@ import {
     installPackages,
     runGenerators,
 } from './dependencies';
-import { packageManagerList, PackageManager } from './package-manager';
+import { packageManagerList } from './package-manager';
+import { CreateStacksArguments, Preset } from './types';
 
-async function determineRepoName(parsedArgv: yargs.Arguments): Promise<string> {
+const presetOptions: { name: Preset; message: string }[] = [
+    {
+        name: Preset.Apps,
+        message:
+            'apps              [an empty monorepo with no plugins with a layout that works best for building apps]',
+    },
+    {
+        name: Preset.TS,
+        message:
+            'ts                [an empty monorepo with the JS/TS plugin preinstalled]',
+    },
+    {
+        name: Preset.ReactMonorepo,
+        message:
+            'react             [a monorepo with a single React application]',
+    },
+    {
+        name: Preset.NextJs,
+        message:
+            'next.js           [a monorepo with a single Next.js application]',
+    },
+];
+
+async function determineRepoName(
+    parsedArgv: yargs.Arguments<CreateStacksArguments>,
+): Promise<string> {
     const repoName = parsedArgv._[0]
         ? parsedArgv._[0].toString()
         : (parsedArgv['name'] as string | undefined);
@@ -40,11 +66,78 @@ async function determineRepoName(parsedArgv: yargs.Arguments): Promise<string> {
         });
 }
 
-async function getConfiguration(argv: yargs.Arguments) {
+async function determinePreset(parsedArguments: any): Promise<Preset> {
+    if (parsedArguments.preset) {
+        if (Object.values(Preset).includes(parsedArguments.preset)) {
+            console.error(chalk.red`Invalid preset: It must be one of the following:
+${Object.values(Preset)}`);
+
+            process.exit(1);
+        } else {
+            return Promise.resolve(parsedArguments.preset);
+        }
+    }
+
+    return enquirer
+        .prompt<{ Preset: Preset }>([
+            {
+                name: 'Preset',
+                message: `What to create in the new workspace  `,
+                initial: 'empty' as any,
+                type: 'autocomplete',
+                choices: presetOptions,
+            },
+        ])
+        .then(a => a.Preset);
+}
+
+async function determineAppName(
+    preset: Preset,
+    parsedArguments: yargs.Arguments<CreateStacksArguments>,
+): Promise<string> {
+    if (preset === Preset.Apps || preset === Preset.TS) {
+        return Promise.resolve('');
+    }
+
+    if (parsedArguments.appName) {
+        return Promise.resolve(parsedArguments.appName);
+    }
+
+    return enquirer
+        .prompt<{ AppName: string }>([
+            {
+                name: 'AppName',
+                message: `Application name                     `,
+                type: 'input',
+            },
+        ])
+        .then(a => {
+            if (!a.AppName) {
+                console.error(chalk.red`Invalid name: Cannot be empty`);
+                process.exit(1);
+            }
+            return a.AppName;
+        });
+}
+
+async function getConfiguration(argv: yargs.Arguments<CreateStacksArguments>) {
     const name = await determineRepoName(argv);
+    let { preset, appName } = argv;
+
+    if (!preset) {
+        preset = await determinePreset(argv);
+    }
+
+    if (preset && !appName) {
+        appName = await determineAppName(preset as Preset, argv);
+    }
 
     Object.assign(argv, {
         name,
+        preset,
+        appName,
+        nxVersion: '',
+        packageManager: '',
     });
 }
 
@@ -81,13 +174,6 @@ async function main(parsedArgv: yargs.Arguments<CreateStacksArguments>) {
     console.log(chalk.magenta`Stacks is ready`);
 }
 
-interface CreateStacksArguments {
-    name: string;
-    preset: string;
-    nxVersion: string;
-    packageManager: PackageManager;
-}
-
 export const commandsObject: yargs.Argv<CreateStacksArguments> = yargs
     .wrap(yargs.terminalWidth())
     .parserConfiguration({ 'strip-dashed': true, 'dot-notation': true })
@@ -98,6 +184,18 @@ export const commandsObject: yargs.Argv<CreateStacksArguments> = yargs
             parsedArgv
                 .option('name', {
                     describe: chalk.dim`Workspace name (e.g. org name)`,
+                    type: 'string',
+                })
+                .option('preset', {
+                    describe: chalk.dim`Customizes the initial content of your workspace. Default presets include: [${Object.values(
+                        Preset,
+                    )
+                        .map(p => `"${p}"`)
+                        .join(', ')}]`,
+                    type: 'string',
+                })
+                .option('appName', {
+                    describe: chalk.dim`The name of the application when a preset with pregenerated app is selected`,
                     type: 'string',
                 })
                 .option('nxVersion', {
@@ -115,5 +213,5 @@ export const commandsObject: yargs.Argv<CreateStacksArguments> = yargs
         async (argv: yargs.ArgumentsCamelCase<CreateStacksArguments>) => {
             return main(argv).catch(console.log);
         },
-        [getConfiguration],
+        [getConfiguration as yargs.MiddlewareFunction],
     );

--- a/packages/create/bin/dependencies.spec.ts
+++ b/packages/create/bin/dependencies.spec.ts
@@ -70,6 +70,7 @@ it('runs generators correctly', async () => {
 it('runs generators for next.js', async () => {
     const generators = getGeneratorsToRun({
         preset: 'next',
+        appName: 'test-app',
     } as yargs.Arguments<CreateStacksArguments>);
     await runGenerators(generators, 'folder/path');
 
@@ -79,7 +80,7 @@ it('runs generators for next.js', async () => {
         'folder/path',
     );
     expect(execAsync).toHaveBeenCalledWith(
-        'npx nx g @ensono-stacks/next:init',
+        'npx nx g @ensono-stacks/next:init --project=test-app',
         'folder/path',
     );
 });

--- a/packages/create/bin/dependencies.spec.ts
+++ b/packages/create/bin/dependencies.spec.ts
@@ -8,17 +8,32 @@ import {
 } from './dependencies';
 import { execAsync, getCommandVersion } from './exec';
 import { detectPackageManager } from './package-manager';
+import type { CreateStacksArguments } from './types';
 
 beforeEach(() => {
     jest.clearAllMocks();
 });
 
 it('installs dependencies correctly', async () => {
-    const packages = getStacksPlugins({} as yargs.Arguments);
+    const packages = getStacksPlugins(
+        {} as yargs.Arguments<CreateStacksArguments>,
+    );
     await installPackages(packages, 'folder/path');
 
     expect(execAsync).toHaveBeenCalledWith(
         'npm install -D @ensono-stacks/workspace',
+        'folder/path',
+    );
+});
+
+it('installs dependencies for next.js', async () => {
+    const packages = getStacksPlugins({
+        preset: 'next',
+    } as yargs.Arguments<CreateStacksArguments>);
+    await installPackages(packages, 'folder/path');
+
+    expect(execAsync).toHaveBeenCalledWith(
+        'npm install -D @ensono-stacks/workspace @ensono-stacks/next',
         'folder/path',
     );
 });
@@ -40,12 +55,31 @@ it('installs dependencies with preferred package manager', async () => {
 });
 
 it('runs generators correctly', async () => {
-    const generators = getGeneratorsToRun({} as yargs.Arguments);
+    const generators = getGeneratorsToRun(
+        {} as yargs.Arguments<CreateStacksArguments>,
+    );
     await runGenerators(generators, 'folder/path');
 
     expect(execAsync).toBeCalledTimes(1);
     expect(execAsync).toHaveBeenCalledWith(
         'npx nx g @ensono-stacks/workspace:init',
+        'folder/path',
+    );
+});
+
+it('runs generators for next.js', async () => {
+    const generators = getGeneratorsToRun({
+        preset: 'next',
+    } as yargs.Arguments<CreateStacksArguments>);
+    await runGenerators(generators, 'folder/path');
+
+    expect(execAsync).toBeCalledTimes(2);
+    expect(execAsync).toHaveBeenCalledWith(
+        'npx nx g @ensono-stacks/workspace:init',
+        'folder/path',
+    );
+    expect(execAsync).toHaveBeenCalledWith(
+        'npx nx g @ensono-stacks/next:init',
         'folder/path',
     );
 });

--- a/packages/create/bin/dependencies.ts
+++ b/packages/create/bin/dependencies.ts
@@ -16,7 +16,7 @@ export function getGeneratorsToRun(
     generators.push(`@ensono-stacks/workspace:init`);
 
     if (argv.preset === Preset.NextJs) {
-        generators.push('@ensono-stacks/next:init');
+        generators.push(`@ensono-stacks/next:init --project=${argv.appName}`);
     }
 
     return generators;

--- a/packages/create/bin/dependencies.ts
+++ b/packages/create/bin/dependencies.ts
@@ -5,20 +5,31 @@ import {
     detectPackageManager,
     getPackageManagerCommand,
 } from './package-manager';
+import { CreateStacksArguments, Preset } from './types';
 
-const stacksRequiredPlugins = [
-    '@ensono-stacks/workspace',
-    // '@ensono-stacks/rest-client',
-];
+const stacksRequiredPlugins = ['@ensono-stacks/workspace'];
 
-export function getGeneratorsToRun(argv: yargs.Arguments) {
+export function getGeneratorsToRun(
+    argv: yargs.Arguments<CreateStacksArguments>,
+) {
     const generators: string[] = [];
     generators.push(`@ensono-stacks/workspace:init`);
+
+    if (argv.preset === Preset.NextJs) {
+        generators.push('@ensono-stacks/next:init');
+    }
+
     return generators;
 }
 
-export function getStacksPlugins(argv: yargs.Arguments) {
-    return stacksRequiredPlugins;
+export function getStacksPlugins(argv: yargs.Arguments<CreateStacksArguments>) {
+    const plugins = [...stacksRequiredPlugins];
+
+    if (argv.preset === Preset.NextJs) {
+        plugins.push('@ensono-stacks/next');
+    }
+
+    return plugins;
 }
 
 export async function installPackages(packages: string[], cwd: string) {

--- a/packages/create/bin/types.ts
+++ b/packages/create/bin/types.ts
@@ -1,0 +1,16 @@
+import { PackageManager } from './package-manager';
+
+export type CreateStacksArguments = {
+    name: string;
+    preset: string;
+    appName: string;
+    nxVersion: string;
+    packageManager: PackageManager;
+};
+
+export enum Preset {
+    Apps = 'apps',
+    TS = 'ts',
+    NextJs = 'next',
+    ReactMonorepo = 'react-monorepo',
+}


### PR DESCRIPTION
Add support for Next Preset.

If using the next preset, `npx @ensono-stacks/create-stacks-workspace --preset=next`, will automatically install `@ensono-stacks/next` and run the `@ensono-stacks/next:init` generator against the created project.