### PR TITLE
fix(azure-node): short options from -dir to -e and -s

### DIFF
--- a/packages/azure-node/src/generators/app-insights/schema.json
+++ b/packages/azure-node/src/generators/app-insights/schema.json
@@ -17,12 +17,12 @@
         "appInsightsKey": {
             "type": "string",
             "description": "The env variable that stores the app insights key.",
-            "alias": "dir"
+            "alias": "e"
         },
         "server": {
             "type": "string",
             "description": "The name of your custom server file",
-            "alias": "dir"
+            "alias": "s"
         }
     },
     "required": ["project", "appInsightsKey", "server"]


### PR DESCRIPTION
Just noticed these `-dir` short options while doing docs.

![Screenshot 2023-01-31 at 13 32 41](https://user-images.githubusercontent.com/802141/215760786-40614f01-650a-4771-9130-ddcb80d8f2d5.png)
