### PR TITLE
fix(azure-node): auto install app insights after generator run

### DIFF
--- a/packages/azure-node/src/generators/app-insights/generator.ts
+++ b/packages/azure-node/src/generators/app-insights/generator.ts
@@ -83,9 +83,6 @@ export default async function appInsightsGenerator(
         }
     });
 
-    // Add dependencies
-    updateDependencies(tree);
-
     // Write changes back to the tree
     tree.write(
         customServerPath,
@@ -94,4 +91,7 @@ export default async function appInsightsGenerator(
 
     // Format files
     await formatFiles(tree);
+
+    // Add dependencies and install
+    return updateDependencies(tree);
 }


### PR DESCRIPTION
[5416](https://dev.azure.com/amido-dev/Amido-Stacks/_workitems/edit/5416)
- returns updateDependencies -> addDependenciesToPackageJson so the callback gets invoked which installs the missing packages