### PR TITLE
fix(workspace): skip taskctl pipeline runner if stacks config is missing

### DIFF
--- a/packages/workspace/src/generators/init/generator.spec.ts
+++ b/packages/workspace/src/generators/init/generator.spec.ts
@@ -255,5 +255,17 @@ npx nx affected:lint --uncommitted`,
             expect(tree.exists('build/taskctl')).toBeTruthy();
             expect(tree.exists('build/azDevOps')).toBeTruthy();
         });
+
+        it('should skip pipeline if stacks config missing', async () => {
+            await generator(tree, {
+                pipelineRunner: 'taskctl',
+                eslint: false,
+                commitizen: false,
+                husky: false,
+            });
+
+            expect(tree.exists('build/taskctl')).not.toBeTruthy();
+            expect(tree.exists('build/azDevOps')).not.toBeTruthy();
+        });
     });
 });


### PR DESCRIPTION
We often don't have stacks configured in `nx.json` when starting from `npx @ensono-stacks/create-stacks-workspace@latest` which causes workspace creation to fail. This should not happen when starting from stacks-cli, but for dev and QA purposes, it should be handy to not crash.

It will issue a warning in the console if `--pipelineRunner` was set:

![Screenshot 2023-02-08 at 12 02 22](https://user-images.githubusercontent.com/802141/217511763-b82c51a5-9c92-4670-a7e4-d511eb738db2.png)