### PR TITLE
fix(create): skip taskctl pipeline runner if stacks config is missing

### DIFF
--- a/e2e/logger-e2e/tests/logger.spec.ts
+++ b/e2e/logger-e2e/tests/logger.spec.ts
@@ -1,7 +1,7 @@
+import { newProject } from '@ensono-stacks/e2e';
 import {
     checkFilesExist,
     cleanup,
-    ensureNxProject,
     readJson,
     runNxCommandAsync,
     uniq,
@@ -9,15 +9,12 @@ import {
 
 describe('logger e2e', () => {
 
-    beforeAll(() => {
-        ensureNxProject(
-            '@ensono-stacks/logger',
-            'dist/packages/logger',
-        );
+    beforeAll(async () => {
+        await newProject(['@ensono-stacks/logger']);
     });
 
-    afterAll(() => {
-        runNxCommandAsync('reset');
+    afterAll(async () => {
+        await runNxCommandAsync('reset');
         cleanup();
     });
 
@@ -53,10 +50,6 @@ describe('logger e2e', () => {
         describe('--tags', () => {
             it('should add tags to the project', async () => {
                 const project = uniq('logger');
-                ensureNxProject(
-                    '@ensono-stacks/logger',
-                    'dist/packages/logger',
-                );
                 await runNxCommandAsync(
                     `generate @ensono-stacks/logger:winston ${project} --tags e2etag,e2ePackage`,
                 );
@@ -66,13 +59,6 @@ describe('logger e2e', () => {
         });
 
         describe('--logLevelType', () => {
-            beforeAll(() => {
-                ensureNxProject(
-                    '@ensono-stacks/logger',
-                    'dist/packages/logger',
-                );
-            });
-
             it('should create src with "cli" log level type', async () => {
                 const project = uniq('logger');
                 await runNxCommandAsync(
@@ -151,13 +137,6 @@ describe('logger e2e', () => {
         });
 
         describe('--httpTransport', () => {
-            beforeEach(() => {
-                ensureNxProject(
-                    '@ensono-stacks/logger',
-                    'dist/packages/logger',
-                );
-            });
-
             it('should create src with http transport being set', async () => {
                 const project = uniq('logger');
                 await runNxCommandAsync(

--- a/packages/create/bin/dependencies.spec.ts
+++ b/packages/create/bin/dependencies.spec.ts
@@ -63,7 +63,7 @@ it('runs generators correctly', async () => {
 
     expect(execAsync).toBeCalledTimes(1);
     expect(execAsync).toHaveBeenCalledWith(
-        'npx nx g @ensono-stacks/workspace:init',
+        'npx nx g @ensono-stacks/workspace:init --pipelineRunner=none',
         'folder/path',
     );
 });
@@ -77,7 +77,7 @@ it('runs generators for next.js', async () => {
 
     expect(execAsync).toBeCalledTimes(2);
     expect(execAsync).toHaveBeenCalledWith(
-        'npx nx g @ensono-stacks/workspace:init',
+        'npx nx g @ensono-stacks/workspace:init --pipelineRunner=none',
         'folder/path',
     );
     expect(execAsync).toHaveBeenCalledWith(

--- a/packages/create/bin/dependencies.ts
+++ b/packages/create/bin/dependencies.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk';
 import yargs from 'yargs';
 
 import { execAsync } from './exec';
@@ -16,11 +17,34 @@ async function chain([promise, ...promises]: (() => Promise<unknown>)[]) {
     }
 }
 
+function checkRequiredArguments(
+    argv: yargs.Arguments<CreateStacksArguments>,
+    required: (keyof CreateStacksArguments)[],
+): boolean {
+    return required.every(key => Boolean(argv[key]));
+}
+
 export function getGeneratorsToRun(
     argv: yargs.Arguments<CreateStacksArguments>,
 ) {
     const generators: string[] = [];
-    generators.push(`@ensono-stacks/workspace:init`);
+
+    let pipelineRunnerOption = '';
+    if (
+        !checkRequiredArguments(argv, [
+            'business',
+            'domain',
+            'cloud',
+            'pipeline',
+        ])
+    ) {
+        pipelineRunnerOption = ' --pipelineRunner=none';
+        console.log(
+            chalk.yellow`Setting --pipelineRunner=none because Stacks config is missing. Did you start using stacks-cli?`,
+        );
+    }
+
+    generators.push(`@ensono-stacks/workspace:init${pipelineRunnerOption}`);
 
     if (argv.preset === Preset.NextJs) {
         generators.push(`@ensono-stacks/next:init --project=${argv.appName}`);


### PR DESCRIPTION
We often don't have stacks configured in nx.json when starting from npx @ensono-stacks/create-stacks-workspace@latest which causes workspace creation to fail. This should not happen when starting from stacks-cli, but for dev and QA purposes, it should be handy to not crash.

It will issue a warning in the console:

![Screenshot 2023-02-08 at 13 31 51](https://user-images.githubusercontent.com/802141/217530489-6ebca1b0-e3a7-4751-8b92-8b66a6b3bfb2.png)

Supersedes #52 .