### PR TITLE
fix(next): removes outputPath from project json dev target build if the same as sourceRoot

### DIFF
--- a/packages/next/src/generators/init/generator.ts
+++ b/packages/next/src/generators/init/generator.ts
@@ -5,6 +5,7 @@ import {
     readProjectConfiguration,
     updateJson,
     Tree,
+    updateProjectConfiguration,
 } from '@nrwl/devkit';
 import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
 import path from 'path';
@@ -20,6 +21,17 @@ export default async function initGenerator(
 ) {
     const tasks: GeneratorCallback[] = [];
     const project = readProjectConfiguration(tree, options.project);
+
+    const update = { ...project };
+
+    if (
+        project.sourceRoot ===
+        update.targets.build.configurations.development.outputPath
+    ) {
+        update.targets.build.configurations.development = {};
+    }
+
+    updateProjectConfiguration(tree, project.name, update);
 
     tasks.push(addEslint(tree, project.root));
 


### PR DESCRIPTION
[5325](https://dev.azure.com/amido-dev/Amido-Stacks/_workitems/edit/5325)

The configuration is not happy when the src and destination of a build bundle is being generated. If no outputPath is supplied, the bundle is automatically created inside the dist folder which is fine. Hence the fix is just a bit of cleanup whereby removing the config if the supplied path is the same as project source.