### PR TITLE
fix(create): fix handling env vars on Windows when executing commands

### DIFF
--- a/packages/create/bin/dependencies.spec.ts
+++ b/packages/create/bin/dependencies.spec.ts
@@ -115,7 +115,7 @@ it('commits additional generator files', async () => {
     expect(execAsync).toHaveBeenNthCalledWith(2, 'git add .', 'folder/path');
     expect(execAsync).toHaveBeenNthCalledWith(
         3,
-        'HUSKY=0 git commit -m "test commit message"',
+        'git commit -m "test commit message"',
         'folder/path',
     );
 });

--- a/packages/create/bin/dependencies.ts
+++ b/packages/create/bin/dependencies.ts
@@ -90,7 +90,8 @@ export async function runGenerators(commands: string[], cwd: string) {
 }
 
 export async function commitGeneratedFiles(cwd: string, message: string) {
+    process.env['HUSKY'] = '0';
     await execAsync(`cd ${cwd}`, cwd);
     await execAsync('git add .', cwd);
-    await execAsync(`HUSKY=0 git commit -m "${message}"`, cwd);
+    await execAsync(`git commit -m "${message}"`, cwd);
 }


### PR DESCRIPTION
It looks like env vars are slightly trickier on Windows:

```
Installing Stacks dependencies
Successfully installed: @ensono-stacks/workspace @ensono-stacks/next
Configuring Stacks
Error: Command failed: HUSKY=0 git commit -m "stacks init"
'HUSKY' is not recognized as an internal or external command,
operable program or batch file.

    at ChildProcess.exithandler (node:child_process:419:12)
    at ChildProcess.emit (node:events:513:28)
    at maybeClose (node:internal/child_process:1091:16)
    at ChildProcess._handle.onexit (node:internal/child_process:302:5) {
  code: 1,
  killed: false,
  signal: null,
  cmd: 'HUSKY=0 git commit -m "stacks init"'
}
'HUSKY' is not recognized as an internal or external command,
operable program or batch file.
```

The fix is to set `process.env['HUSKY']` as the `execAsync` function copies current env values to the child process.