### PR TITLE
feat(create): add support for custom dir and overwrite

### DIFF
--- a/e2e/create-e2e/tests/create.spec.ts
+++ b/e2e/create-e2e/tests/create.spec.ts
@@ -41,22 +41,26 @@ describe('create', () => {
         if (fs.existsSync(cacheDirectory)) {
             fs.rmSync(cacheDirectory, { recursive: true, force: true });
         }
+    });
+
+    afterEach(() => {
         cleanup();
     });
 
     it('configures an empty apps stacks workspace', async () => {
-        const run = () => execSync(
-            'npx --yes @ensono-stacks/create-stacks-workspace@latest proj --business.company=Ensono --business.domain=Stacks --business.component=Nx --cloud.platform=azure --cloud.region=euw --domain.internal=nonprod.amidostacks.com --domain.external=prod.amidostacks.com --terraform.group=tf-group --terraform.storage=tf-storage --terraform.container=tf-container --vcs.type=github --preset=apps --no-nxCloud --skipGit --no-interactive --verbose',
-            {
-                cwd: temporaryDirectory,
-                stdio: 'inherit',
-                env: {
-                    ...process.env,
-                    npm_config_cache: cacheDirectory,
-                    HUSKY: '0',
+        const run = () =>
+            execSync(
+                'npx --yes @ensono-stacks/create-stacks-workspace@latest proj --business.company=Ensono --business.domain=Stacks --business.component=Nx --cloud.platform=azure --cloud.region=euw --domain.internal=nonprod.amidostacks.com --domain.external=prod.amidostacks.com --terraform.group=tf-group --terraform.storage=tf-storage --terraform.container=tf-container --vcs.type=github --preset=apps --no-nxCloud --skipGit --no-interactive --verbose',
+                {
+                    cwd: temporaryDirectory,
+                    stdio: 'inherit',
+                    env: {
+                        ...process.env,
+                        npm_config_cache: cacheDirectory,
+                        HUSKY: '0',
+                    },
                 },
-            },
-        );
+            );
 
         expect(() => run()).not.toThrow();
 
@@ -113,5 +117,29 @@ describe('create', () => {
         );
         // rerunning should throw because the workspace exists
         expect(() => run()).toThrow();
+    });
+
+    it('can install to a specific directory', async () => {
+        execSync(
+            'npx --yes @ensono-stacks/create-stacks-workspace@latest test --dir=./proj --business.company=Ensono --business.domain=Stacks --business.component=Nx --cloud.platform=azure --cloud.region=euw --domain.internal=nonprod.amidostacks.com --domain.external=prod.amidostacks.com --terraform.group=tf-group --terraform.storage=tf-storage --terraform.container=tf-container --vcs.type=github --preset=apps --no-nxCloud --skipGit --no-interactive --verbose',
+            {
+                cwd: temporaryDirectory,
+                stdio: 'inherit',
+                env: {
+                    ...process.env,
+                    npm_config_cache: cacheDirectory,
+                    HUSKY: '0',
+                },
+            },
+        );
+
+        expect(() =>
+            checkFilesExist(
+                'test/.eslintrc.json',
+                'test/.husky/commit-msg',
+                'test/.husky/pre-commit',
+                'test/.husky/prepare-commit-msg',
+            ),
+        ).not.toThrow();
     });
 });

--- a/packages/create/bin/types.ts
+++ b/packages/create/bin/types.ts
@@ -2,11 +2,13 @@ import { PackageManager } from './package-manager';
 
 export type CreateStacksArguments = {
     name: string;
+    dir: string;
     preset: string;
     appName: string;
     nxVersion: string;
     packageManager: PackageManager;
     interactive: boolean;
+    overwrite: boolean;
     terraform: {
         group: string;
         container: string;


### PR DESCRIPTION
The `stacks-cli` integration with the create script is almost done. However there are a few blockers.

Stacks-CLI goes through the following flow when bootstrapping a project:

1. Creates the project Working Directory.
2. Runs `init` & `setup` commands from the Temp Directory.

We can't afford to install in a temp directory, as copying across `node_modules` will take way too long.

The changes to `create` introduce two new flags:
- `--dir`: the ability to set the directory into which the workspace gets created.
-  `--overwrite`: if the resolved installation path already exists, it will remove the path.

```sh
# cwd: .
# └─┬ folder
#   └── project

npx @ensono-stacks/create project --dir=./folder --overwrite

# cwd: .
# └─┬ folder
#   └─┬ project
#     └── nx.json
```