### PR TITLE
fix(create): check dir name matches project name with overwrite

### DIFF
--- a/e2e/create-e2e/tests/create.spec.ts
+++ b/e2e/create-e2e/tests/create.spec.ts
@@ -28,7 +28,6 @@ describe('create', () => {
 
     beforeEach(() => {
         if (!fs.existsSync(temporaryDirectory)) {
-            console.log('creating ' + temporaryDirectory);
             fs.mkdirSync(temporaryDirectory, {
                 recursive: true,
             });
@@ -43,7 +42,6 @@ describe('create', () => {
 
     afterEach(() => {
         if (fs.existsSync(temporaryDirectory)) {
-            console.log('removing ' + temporaryDirectory);
             fs.rmSync(temporaryDirectory, {
                 recursive: true,
                 force: true,
@@ -93,39 +91,38 @@ describe('create', () => {
 
         expect(nxJson.stacks).toMatchObject(
             expect.objectContaining({
-                    business: {
-                        company: 'Ensono',
-                        component: 'Nx',
-                        domain: 'Stacks',
-                    },
-                    cloud: {
-                        platform: 'azure',
-                        region: 'euw',
-                    },
-                    domain: {
-                        external: 'prod.amidostacks.com',
-                        internal: 'nonprod.amidostacks.com',
-                    },
-                    pipeline: 'azdo',
-                    terraform: {
-                        container: 'tf-container',
-                        group: 'tf-group',
-                        storage: 'tf-storage',
-                    },
-                    vcs: {
-                        type: 'github',
-                        url: 'remote.git',
-                    },
+                business: {
+                    company: 'Ensono',
+                    component: 'Nx',
+                    domain: 'Stacks',
                 },
-            ),
+                cloud: {
+                    platform: 'azure',
+                    region: 'euw',
+                },
+                domain: {
+                    external: 'prod.amidostacks.com',
+                    internal: 'nonprod.amidostacks.com',
+                },
+                pipeline: 'azdo',
+                terraform: {
+                    container: 'tf-container',
+                    group: 'tf-group',
+                    storage: 'tf-storage',
+                },
+                vcs: {
+                    type: 'github',
+                    url: 'remote.git',
+                },
+            }),
         );
         // rerunning should throw because the workspace exists
         expect(() => run()).toThrow();
     });
 
-    it('can install to a specific directory', async () => {
+    it('can install within a specific directory if it does not exist', async () => {
         execSync(
-            'npx --yes @ensono-stacks/create-stacks-workspace@latest test --dir=./proj --business.company=Ensono --business.domain=Stacks --business.component=Nx --cloud.platform=azure --cloud.region=euw --domain.internal=nonprod.amidostacks.com --domain.external=prod.amidostacks.com --terraform.group=tf-group --terraform.storage=tf-storage --terraform.container=tf-container --vcs.type=github --preset=apps --no-nxCloud --skipGit --no-interactive --verbose',
+            'npx --yes @ensono-stacks/create-stacks-workspace@latest ProjectTest --dir=./proj/project-name --business.company=Ensono --business.domain=Stacks --business.component=Nx --cloud.platform=azure --cloud.region=euw --domain.internal=nonprod.amidostacks.com --domain.external=prod.amidostacks.com --terraform.group=tf-group --terraform.storage=tf-storage --terraform.container=tf-container --vcs.type=github --preset=apps --no-nxCloud --skipGit --no-interactive --verbose',
             {
                 cwd: temporaryDirectory,
                 stdio: 'inherit',
@@ -139,11 +136,66 @@ describe('create', () => {
 
         expect(() =>
             checkFilesExist(
-                'test/.eslintrc.json',
-                'test/.husky/commit-msg',
-                'test/.husky/pre-commit',
-                'test/.husky/prepare-commit-msg',
+                'project-name/.eslintrc.json',
+                'project-name/.husky/commit-msg',
+                'project-name/.husky/pre-commit',
+                'project-name/.husky/prepare-commit-msg',
             ),
         ).not.toThrow();
+    });
+
+    it('throws when dir already exists without overwrite', async () => {
+        fs.mkdirSync(path.join(temporaryDirectory, 'proj', 'project-name'), {
+            recursive: true,
+        });
+        const run = () =>
+            execSync(
+                'npx --yes @ensono-stacks/create-stacks-workspace@latest ProjectTest --dir=./proj/project-name --business.company=Ensono --business.domain=Stacks --business.component=Nx --cloud.platform=azure --cloud.region=euw --domain.internal=nonprod.amidostacks.com --domain.external=prod.amidostacks.com --terraform.group=tf-group --terraform.storage=tf-storage --terraform.container=tf-container --vcs.type=github --preset=apps --no-nxCloud --skipGit --no-interactive --verbose',
+                {
+                    cwd: temporaryDirectory,
+                    stdio: 'inherit',
+                    env: {
+                        ...process.env,
+                        npm_config_cache: cacheDirectory,
+                        HUSKY: '0',
+                    },
+                },
+            );
+
+        expect(() => run()).toThrow();
+    });
+
+    it('can install to a specific directory with overwrite (stacks-cli)', async () => {
+        fs.mkdirSync(path.join(temporaryDirectory, 'proj', 'ProjectName'), {
+            recursive: true,
+        });
+        execSync(
+            'npx --yes @ensono-stacks/create-stacks-workspace@latest ProjectTest --dir=./proj/ProjectName --overwrite --business.company=Ensono --business.domain=Stacks --business.component=Nx --cloud.platform=azure --cloud.region=euw --domain.internal=nonprod.amidostacks.com --domain.external=prod.amidostacks.com --terraform.group=tf-group --terraform.storage=tf-storage --terraform.container=tf-container --vcs.type=github --preset=apps --no-nxCloud --skipGit --no-interactive --verbose',
+            {
+                cwd: temporaryDirectory,
+                stdio: 'inherit',
+                env: {
+                    ...process.env,
+                    npm_config_cache: cacheDirectory,
+                    HUSKY: '0',
+                },
+            },
+        );
+
+        expect(() =>
+            checkFilesExist(
+                'ProjectName/.eslintrc.json',
+                'ProjectName/.husky/commit-msg',
+                'ProjectName/.husky/pre-commit',
+                'ProjectName/.husky/prepare-commit-msg',
+            ),
+        ).not.toThrow();
+
+        const nxJson = readJson('ProjectName/nx.json');
+        expect(nxJson).toMatchObject(
+            expect.objectContaining({
+                npmScope: 'project-test',
+            }),
+        );
     });
 });

--- a/e2e/create-e2e/tests/create.spec.ts
+++ b/e2e/create-e2e/tests/create.spec.ts
@@ -2,13 +2,10 @@ import {
     tmpProjPath,
     checkFilesExist,
     readJson,
-    runNxCommandAsync,
 } from '@nrwl/nx-plugin/testing';
 import { execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
-
-import { cleanup } from '@ensono-stacks/e2e';
 
 describe('create', () => {
     const temporaryDirectory = path.dirname(tmpProjPath());
@@ -20,19 +17,20 @@ describe('create', () => {
                 recursive: true,
             });
         }
+
+        if (fs.existsSync(path.join(temporaryDirectory))) {
+            fs.rmSync(path.join(temporaryDirectory), {
+                recursive: true,
+                force: true,
+            });
+        }
     });
 
     beforeEach(() => {
         if (!fs.existsSync(temporaryDirectory)) {
+            console.log('creating ' + temporaryDirectory);
             fs.mkdirSync(temporaryDirectory, {
                 recursive: true,
-            });
-        }
-
-        if (fs.existsSync(path.join(temporaryDirectory, 'proj'))) {
-            fs.rmSync(path.join(temporaryDirectory, 'proj'), {
-                recursive: true,
-                force: true,
             });
         }
     });
@@ -44,7 +42,13 @@ describe('create', () => {
     });
 
     afterEach(() => {
-        cleanup();
+        if (fs.existsSync(temporaryDirectory)) {
+            console.log('removing ' + temporaryDirectory);
+            fs.rmSync(temporaryDirectory, {
+                recursive: true,
+                force: true,
+            });
+        }
     });
 
     it('configures an empty apps stacks workspace', async () => {

--- a/packages/create/bin/create-stacks-workspace.ts
+++ b/packages/create/bin/create-stacks-workspace.ts
@@ -164,7 +164,7 @@ async function main(parsedArgv: yargs.Arguments<CreateStacksArguments>) {
 
     const targetDirectory = path.resolve(dir);
     const isTargetDirectoryCurrent = targetDirectory === process.cwd();
-    console.log({ isTargetDirectoryCurrent, targetDirectory });
+
     if (!isTargetDirectoryCurrent && fs.existsSync(targetDirectory)) {
         if (overwrite) {
             fs.rmSync(targetDirectory, { recursive: true, force: true });
@@ -200,8 +200,6 @@ async function main(parsedArgv: yargs.Arguments<CreateStacksArguments>) {
             stdio: 'inherit',
         },
     );
-
-    console.log(nxResult);
 
     if (nxResult.status !== 0) {
         console.error(

--- a/packages/create/bin/exec.ts
+++ b/packages/create/bin/exec.ts
@@ -15,7 +15,6 @@ export function execAsync(
             },
             (error, stdout, stderr) => {
                 if (error) {
-                    console.log(error);
                     reject(stderr);
                 } else {
                     response(stdout);

--- a/packages/create/bin/types.ts
+++ b/packages/create/bin/types.ts
@@ -9,6 +9,7 @@ export type CreateStacksArguments = {
     packageManager: PackageManager;
     interactive: boolean;
     overwrite: boolean;
+    skipGit: boolean;
     terraform: {
         group: string;
         container: string;


### PR DESCRIPTION
Stacks-cli controls the creation of the root project directory, and merges the working dir defined in you `stacks.yml` file with the project name.

This becomes problematic resulting in double nested folders: 
```yaml
directory:
  working: /root
project:
  - name: ProjectName
```
Expected: `/root/project-name`
Actual: `/root/ProjectName/project-name`

I've altered the behaviour of the flag `overwrite` to handle detecting if the `dir`'s basename matches the project name.


