### PR TITLE
feat(next): add --redisAdapter flag to generate Redis adapter for Next Auth

### DIFF
--- a/e2e/next-e2e/tests/next.spec.ts
+++ b/e2e/next-e2e/tests/next.spec.ts
@@ -49,4 +49,24 @@ describe('next e2e', () => {
 
         expect(stdout).toContain('Compiled successfully');
     }, 200_000);
+
+    it('configures NextAuth with Redis adapter', async () => {
+        await runNxCommandAsync(
+            `generate @nrwl/next:application ${project} --e2eTestRunner=none`,
+        );
+        await runNxCommandAsync(
+            `generate @ensono-stacks/next:init --project=${project} --no-interactive`,
+        );
+        const res = await runNxCommandAsync(
+            `generate @ensono-stacks/next:next-auth --project=${project} --provider=azureAd --redisAdapter --no-interactive`,
+        );
+        expect(() =>
+            checkFilesExist(
+                `apps/${project}/pages/api/auth/[...nextauth].ts`,
+                `apps/${project}/.env.local`,
+                `libs/next-auth-redis/src/index.test.ts`,
+                `libs/next-auth-redis/src/index.ts`,
+            ),
+        ).not.toThrow();
+    }, 200_000);
 });

--- a/packages/next/src/generators/next-auth/__snapshots__/generator.spec.ts.snap
+++ b/packages/next/src/generators/next-auth/__snapshots__/generator.spec.ts.snap
@@ -59,6 +59,63 @@ export default CustomApp;
 "
 `;
 
+exports[`next-auth generator should generate redis adapter lib 1`] = `
+"import NextAuth from 'next-auth';
+import AzureADProvider from \\"next-auth/providers/azure-ad\\";
+import { IORedisAdapter } from \\"proj/next-auth-redis\\";
+import { Redis } from \\"ioredis\\";
+
+const nextAuth = NextAuth({
+    providers: [AzureADProvider({
+            clientId: process.env.AZURE_AD_CLIENT_ID,
+            clientSecret: process.env.AZURE_AD_CLIENT_SECRET,
+            tenantId: process.env.AZURE_AD_TENANT_ID,
+        })],
+    adapter: IORedisAdapter(new Redis(process.env.REDIS_URL))
+})
+
+export default nextAuth;
+"
+`;
+
+exports[`next-auth generator should generate redis adapter lib with custom env var name 1`] = `
+"import NextAuth from 'next-auth';
+import AzureADProvider from \\"next-auth/providers/azure-ad\\";
+import { IORedisAdapter } from \\"proj/next-auth-redis\\";
+import { Redis } from \\"ioredis\\";
+
+const nextAuth = NextAuth({
+    providers: [AzureADProvider({
+            clientId: process.env.AZURE_AD_CLIENT_ID,
+            clientSecret: process.env.AZURE_AD_CLIENT_SECRET,
+            tenantId: process.env.AZURE_AD_TENANT_ID,
+        })],
+    adapter: IORedisAdapter(new Redis(process.env.REDIS_CONNECTION_STRING))
+})
+
+export default nextAuth;
+"
+`;
+
+exports[`next-auth generator should generate redis adapter lib with custom name 1`] = `
+"import NextAuth from 'next-auth';
+import AzureADProvider from \\"next-auth/providers/azure-ad\\";
+import { IORedisAdapter } from \\"proj/redis-adapter-for-next-auth\\";
+import { Redis } from \\"ioredis\\";
+
+const nextAuth = NextAuth({
+    providers: [AzureADProvider({
+            clientId: process.env.AZURE_AD_CLIENT_ID,
+            clientSecret: process.env.AZURE_AD_CLIENT_SECRET,
+            tenantId: process.env.AZURE_AD_TENANT_ID,
+        })],
+    adapter: IORedisAdapter(new Redis(process.env.REDIS_URL))
+})
+
+export default nextAuth;
+"
+`;
+
 exports[`next-auth generator should install NextAuth with a provider 1`] = `
 "import NextAuth from 'next-auth';
 import AzureADProvider from \\"next-auth/providers/azure-ad\\";

--- a/packages/next/src/generators/next-auth/files-redis/src/index.test.ts__template__
+++ b/packages/next/src/generators/next-auth/files-redis/src/index.test.ts__template__
@@ -1,0 +1,316 @@
+/**
+ * COPIED AND ADJUSTED FROM
+ * https://github.com/nextauthjs/next-auth/blob/main/packages/adapter-test/index.ts
+ *
+ * which is used by
+ * https://github.com/nextauthjs/next-auth/blob/main/packages/adapter-upstash-redis/tests/index.test.ts
+ */
+
+/* eslint-disable unicorn/prevent-abbreviations */
+import { createHash, randomUUID } from 'crypto';
+import { Redis } from 'ioredis';
+
+import { hydrateDates, IORedisAdapter } from '.';
+
+if (!process.env.<%= envVar %>) {
+  test("Skipping IORedisAdapter tests, since required environment variable <%= envVar %> isn't available", () => {
+    expect(true).toBe(true);
+  });
+  // eslint-disable-next-line unicorn/no-process-exit
+  process.exit(0);
+}
+
+const ONE_WEEK_FROM_NOW = new Date(Date.now() + 1000 * 60 * 60 * 24 * 7);
+const FIFTEEN_MINUTES_FROM_NOW = new Date(Date.now() + 15 * 60 * 1000);
+const ONE_MONTH = 1000 * 60 * 60 * 24 * 30;
+const ONE_MONTH_FROM_NOW = new Date(Date.now() + ONE_MONTH);
+
+function hashToken(token: string) {
+  return createHash('sha256').update(`${token}anything`).digest('hex');
+}
+
+describe('Next Auth Redis Adapter', () => {
+  const client = new Redis(process.env.<%= envVar %>);
+  const adapter = IORedisAdapter(client, { baseKeyPrefix: 'testApp:' });
+  const db = {
+    async user(id: string) {
+      const data = await client.hgetall(`testApp:user:${id}`);
+      if (!data || Object.keys(data).length === 0) return null;
+      return hydrateDates(data);
+    },
+    async account({ provider, providerAccountId }) {
+      const data = await client.hgetall(
+        `testApp:account:${provider}:${providerAccountId}`
+      );
+      if (!data || Object.keys(data).length === 0) return null;
+      return hydrateDates(data);
+    },
+    async session(sessionToken) {
+      const data = await client.hgetall(`testApp:session:${sessionToken}`);
+      if (!data || Object.keys(data).length === 0) return null;
+      return hydrateDates(data);
+    },
+    async verificationToken(where) {
+      const data = await client.hgetall(`testApp:token:${where.identifier}`);
+      if (!data) return null;
+      return hydrateDates(data);
+    },
+  };
+
+  afterAll(() => {
+    client.disconnect();
+  });
+
+  let user: any = {
+    email: 'john@doe.com',
+    image: 'https://www.johndoe.com/460/300',
+    name: 'John Doe',
+    emailVerified: new Date(),
+  };
+
+  const session: any = {
+    sessionToken: randomUUID(),
+    expires: ONE_WEEK_FROM_NOW,
+  };
+
+  const account: any = {
+    provider: 'github',
+    providerAccountId: randomUUID(),
+    type: 'oauth',
+    access_token: randomUUID(),
+    expires_at: ONE_MONTH.toString(),
+    id_token: randomUUID(),
+    refresh_token: randomUUID(),
+    token_type: 'bearer',
+    scope: 'user',
+    session_state: randomUUID(),
+  };
+
+  test('Required (User, Account, Session) methods exist', () => {
+    const requiredMethods = [
+      'createUser',
+      'getUser',
+      'getUserByEmail',
+      'getUserByAccount',
+      'updateUser',
+      'linkAccount',
+      'createSession',
+      'getSessionAndUser',
+      'updateSession',
+      'deleteSession',
+    ];
+    requiredMethods.forEach((method) => {
+      expect(adapter).toHaveProperty(method);
+    });
+  });
+
+  test('createUser', async () => {
+    const { id } = await adapter.createUser(user);
+    const dbUser = await db.user(id);
+    expect(dbUser).toEqual({ ...user, id });
+    user = dbUser;
+    session.userId = dbUser.id;
+    account.userId = dbUser.id;
+  });
+
+  test('getUser', async () => {
+    expect(await adapter.getUser(randomUUID())).toBeNull();
+    expect(await adapter.getUser(user.id)).toEqual(user);
+  });
+
+  test('getUserByEmail', async () => {
+    expect(await adapter.getUserByEmail('non-existent-email')).toBeNull();
+    expect(await adapter.getUserByEmail(user.email)).toEqual(user);
+  });
+
+  test('createSession', async () => {
+    const { sessionToken } = await adapter.createSession(session);
+    const dbSession = await db.session(sessionToken);
+
+    expect(dbSession).toEqual({ ...session, id: dbSession.id });
+    session.userId = dbSession.userId;
+    session.id = dbSession.id;
+  });
+
+  test('getSessionAndUser', async () => {
+    let sessionAndUser = await adapter.getSessionAndUser('invalid-token');
+    expect(sessionAndUser).toBeNull();
+
+    sessionAndUser = await adapter.getSessionAndUser(session.sessionToken);
+    if (!sessionAndUser) {
+      throw new Error('Session and User was not found, but they should exist');
+    }
+    expect(sessionAndUser).toEqual({
+      user,
+      session,
+    });
+  });
+
+  test('updateUser', async () => {
+    const newName = 'Updated Name';
+    const returnedUser = await adapter.updateUser({
+      id: user.id,
+      name: newName,
+    });
+    expect(returnedUser.name).toBe(newName);
+
+    const dbUser = await db.user(user.id);
+    expect(dbUser.name).toBe(newName);
+    user.name = newName;
+  });
+
+  test('updateSession', async () => {
+    let dbSession = await db.session(session.sessionToken);
+
+    expect(dbSession.expires.valueOf()).not.toBe(ONE_MONTH_FROM_NOW.valueOf());
+
+    await adapter.updateSession({
+      sessionToken: session.sessionToken,
+      expires: ONE_MONTH_FROM_NOW,
+    });
+
+    dbSession = await db.session(session.sessionToken);
+    expect(dbSession.expires.valueOf()).toBe(ONE_MONTH_FROM_NOW.valueOf());
+  });
+
+  test('linkAccount', async () => {
+    await adapter.linkAccount(account);
+    const dbAccount = await db.account({
+      provider: account.provider,
+      providerAccountId: account.providerAccountId,
+    });
+    expect(dbAccount).toEqual({ ...account, id: dbAccount.id });
+  });
+
+  test('getUserByAccount', async () => {
+    let userByAccount = await adapter.getUserByAccount({
+      provider: 'invalid-provider',
+      providerAccountId: 'invalid-provider-account-id',
+    });
+    expect(userByAccount).toBeNull();
+
+    userByAccount = await adapter.getUserByAccount({
+      provider: account.provider,
+      providerAccountId: account.providerAccountId,
+    });
+    expect(userByAccount).toEqual(user);
+  });
+
+  test('deleteSession', async () => {
+    await adapter.deleteSession(session.sessionToken);
+    const dbSession = await db.session(session.sessionToken);
+    expect(dbSession).toBeNull();
+  });
+
+  // These are optional for custom adapters, but we require them for the official adapters
+
+  test('Verification Token methods exist', () => {
+    const requiredMethods = ['createVerificationToken', 'useVerificationToken'];
+    requiredMethods.forEach((method) => {
+      expect(adapter).toHaveProperty(method);
+    });
+  });
+
+  test('createVerificationToken', async () => {
+    const identifier = 'info@example.com';
+    const token = randomUUID();
+    const hashedToken = hashToken(token);
+
+    const verificationToken = {
+      token: hashedToken,
+      identifier,
+      expires: FIFTEEN_MINUTES_FROM_NOW,
+    };
+    await adapter.createVerificationToken?.(verificationToken);
+
+    const dbVerificationToken = await db.verificationToken({
+      token: hashedToken,
+      identifier,
+    });
+
+    expect(dbVerificationToken).toEqual(verificationToken);
+  });
+
+  test('useVerificationToken', async () => {
+    const identifier = 'info@example.com';
+    const token = randomUUID();
+    const hashedToken = hashToken(token);
+    const verificationToken = {
+      token: hashedToken,
+      identifier,
+      expires: FIFTEEN_MINUTES_FROM_NOW,
+    };
+    await adapter.createVerificationToken?.(verificationToken);
+
+    const dbVerificationToken1 = await adapter.useVerificationToken?.({
+      identifier,
+      token: hashedToken,
+    });
+
+    if (!dbVerificationToken1) {
+      throw new Error('Verification Token was not found, but it should exist');
+    }
+
+    expect(dbVerificationToken1).toEqual(verificationToken);
+
+    const dbVerificationToken2 = await adapter.useVerificationToken?.({
+      identifier,
+      token: hashedToken,
+    });
+
+    expect(dbVerificationToken2).toBeNull();
+  });
+
+  // Future methods
+  // These methods are not yet invoked in the core, but built-in adapters must implement them
+  test('Future methods exist', () => {
+    const requiredMethods = ['unlinkAccount', 'deleteUser'];
+    requiredMethods.forEach((method) => {
+      expect(adapter).toHaveProperty(method);
+    });
+  });
+
+  test('unlinkAccount', async () => {
+    let dbAccount = await db.account({
+      provider: account.provider,
+      providerAccountId: account.providerAccountId,
+    });
+    expect(dbAccount).toEqual({ ...account, id: dbAccount.id });
+
+    await adapter.unlinkAccount?.({
+      provider: account.provider,
+      providerAccountId: account.providerAccountId,
+    });
+    dbAccount = await db.account({
+      provider: account.provider,
+      providerAccountId: account.providerAccountId,
+    });
+    expect(dbAccount).toBeNull();
+  });
+
+  test('deleteUser', async () => {
+    let dbUser = await db.user(user.id);
+    expect(dbUser).toEqual(user);
+
+    // Re-populate db with session and account
+    delete session.id;
+    await adapter.createSession(session);
+    await adapter.linkAccount(account);
+
+    await adapter.deleteUser?.(user.id);
+    dbUser = await db.user(user.id);
+    // User should not exist after it is deleted
+    expect(dbUser).toBeNull();
+
+    const dbSession = await db.session(session.sessionToken);
+    // Session should not exist after user is deleted
+    expect(dbSession).toBeNull();
+
+    const dbAccount = await db.account({
+      provider: account.provider,
+      providerAccountId: account.providerAccountId,
+    });
+    // Account should not exist after user is deleted
+    expect(dbAccount).toBeNull();
+  });
+});

--- a/packages/next/src/generators/next-auth/files-redis/src/index.ts__template__
+++ b/packages/next/src/generators/next-auth/files-redis/src/index.ts__template__
@@ -1,0 +1,273 @@
+/**
+ * COPIED AND ADJUSTED FROM
+ * https://github.com/quanhua92/next-auth-ioredis-adapter-example/blob/main/lib/IORedisAdapter.ts
+ *
+ * which in turn was based off
+ * https://github.com/nextauthjs/next-auth/blob/main/packages/adapter-upstash-redis/src/index.ts
+ */
+
+/* eslint-disable unicorn/consistent-function-scoping */
+import type { Redis } from 'ioredis';
+import type {
+  Adapter,
+  AdapterAccount,
+  AdapterUser,
+  AdapterSession as BaseAdapterSession,
+  VerificationToken,
+} from 'next-auth/adapters';
+import { v4 as uuid } from 'uuid';
+
+export interface IORedisAdapterOptions {
+  baseKeyPrefix?: string;
+  userKeyPrefix?: string;
+  accountKeyPrefix?: string;
+  accountByUserIdPrefix?: string;
+  sessionKeyPrefix?: string;
+  sessionByUserIdPrefix?: string;
+  userByEmailKeyPrefix?: string;
+  verificationKeyPrefix?: string;
+}
+
+export const defaultOptions: IORedisAdapterOptions = {
+  baseKeyPrefix: '',
+  userKeyPrefix: 'user:',
+  accountKeyPrefix: 'account:',
+  accountByUserIdPrefix: 'account:user:',
+  sessionKeyPrefix: 'session:',
+  sessionByUserIdPrefix: 'session:user:',
+  userByEmailKeyPrefix: 'user:email:',
+  verificationKeyPrefix: 'token:',
+};
+
+interface AdapterSession extends BaseAdapterSession {
+  id?: string;
+}
+
+const isoDateRE =
+  /(\d{4}-[01]\d-[0-3]\dT[0-2](?:\d:[0-5]){2}\d\.\d+([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2](?:\d:[0-5]){2}\d([+-][0-2]\d:[0-5]\d|Z))|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z))/;
+
+const isDate = (value: any) => {
+  return value && isoDateRE.test(value) && !Number.isNaN(Date.parse(value));
+};
+
+export function hydrateDates(object: object) {
+  return Object.entries(object).reduce((accumulator, [key, value]) => {
+    accumulator[key] = isDate(value) ? new Date(value as string) : value;
+    return accumulator;
+  }, {} as any);
+}
+
+export function IORedisAdapter(
+  client: Redis,
+  options: IORedisAdapterOptions = {}
+): Adapter {
+  const currentOptions = {
+    ...defaultOptions,
+    ...options,
+  };
+
+  const baseKeyPrefix = currentOptions.baseKeyPrefix || '';
+  const userKeyPrefix = baseKeyPrefix + currentOptions.userKeyPrefix;
+  const userByEmailKeyPrefix =
+    baseKeyPrefix + currentOptions.userByEmailKeyPrefix;
+  const accountKeyPrefix = baseKeyPrefix + currentOptions.accountKeyPrefix;
+  const accountByUserIdPrefix =
+    baseKeyPrefix + currentOptions.accountByUserIdPrefix;
+  const sessionKeyPrefix = baseKeyPrefix + currentOptions.sessionKeyPrefix;
+  const sessionByUserIdPrefix =
+    baseKeyPrefix + currentOptions.sessionByUserIdPrefix;
+  const verificationKeyPrefix =
+    baseKeyPrefix + currentOptions.verificationKeyPrefix;
+
+  const getUserByEmailKey = (email: string) => userByEmailKeyPrefix + email;
+  const getUserKey = (userId: string) => userKeyPrefix + userId;
+
+  const getAccountKey = (accountId: string) => accountKeyPrefix + accountId;
+  const getAccountByUserIdKey = (userId: string) =>
+    accountByUserIdPrefix + userId;
+  const getAccountId = (providerAccountId: string, provider: string) =>
+    `${provider}:${providerAccountId}`;
+
+  const getSessionKey = (sessionId: string) => sessionKeyPrefix + sessionId;
+  const getSessionByUserIdKey = (userId: string) =>
+    sessionByUserIdPrefix + userId;
+
+  const getVerificationKey = (tokenId: string) =>
+    verificationKeyPrefix + tokenId;
+
+  const setObjectAsHash = async (key: string, object: any) => {
+    const newObject = Object.entries(object).reduce(
+      (accumulator, [property, value]) => {
+        accumulator[property] =
+          value instanceof Date ? value.toISOString() : value;
+        return accumulator;
+      },
+      {} as any
+    );
+    await client.hset(key, newObject);
+  };
+
+  const loadObjectFromHash = async (key: string) => {
+    const object = await client.hgetall(key);
+    if (!object || Object.keys(object).length === 0) return null;
+    const newObject = hydrateDates(object);
+    return newObject;
+  };
+
+  const setUser = async (
+    id: string,
+    user: AdapterUser
+  ): Promise<AdapterUser> => {
+    await setObjectAsHash(getUserKey(id), user);
+    if (user.email) await client.set(getUserByEmailKey(user.email), id);
+    return user;
+  };
+
+  const getUser = async (id: string) => {
+    const user = await loadObjectFromHash(getUserKey(id));
+    if (!user) return null;
+    return { ...user } as AdapterUser;
+  };
+
+  const setAccount = async (id: string, account: AdapterAccount) => {
+    const accountKey = getAccountKey(id);
+    await setObjectAsHash(accountKey, account);
+    await client.set(getAccountByUserIdKey(account.userId), accountKey);
+    return account;
+  };
+
+  const getAccount = async (id: string) => {
+    const account = await loadObjectFromHash(getAccountKey(id));
+    if (!account) return null;
+    return { ...account } as AdapterAccount;
+  };
+
+  const deleteAccount = async (id: string) => {
+    const key = getAccountKey(id);
+    const account = await loadObjectFromHash(key);
+    if (!account) return;
+    await client.del(key);
+    await client.del(getAccountByUserIdKey(account.userId));
+  };
+
+  const setSession = async (id: string, session: AdapterSession) => {
+    const sessionKey = getSessionKey(id);
+    await setObjectAsHash(sessionKey, session);
+    await client.set(getSessionByUserIdKey(session.userId), sessionKey);
+    return session;
+  };
+
+  const getSession = async (id: string) => {
+    const session = await loadObjectFromHash(getSessionKey(id));
+    if (!session) return null;
+    return {
+      id: session.id,
+      ...session,
+    } as AdapterSession;
+  };
+
+  const deleteSession = async (sessionToken: string) => {
+    const session = await getSession(sessionToken);
+    if (!session) return;
+    const key = getSessionKey(sessionToken);
+    await client.del(key);
+    await client.del(getSessionByUserIdKey(session.userId));
+  };
+
+  const setVerificationToken = async (id: string, token: VerificationToken) => {
+    const tokenKey = getVerificationKey(id);
+    await setObjectAsHash(tokenKey, token);
+    return token;
+  };
+
+  const getVerificationToken = async (id: string) => {
+    const tokenKey = getVerificationKey(id);
+    const token = await loadObjectFromHash(tokenKey);
+    if (!token) return null;
+    return { identifier: token.identifier, ...token } as VerificationToken;
+  };
+
+  const deleteVerificationToken = async (id: string) => {
+    const tokenKey = getVerificationKey(id);
+    await client.del(tokenKey);
+  };
+
+  return {
+    async createUser(user) {
+      const id = uuid();
+      return setUser(id, { ...user, id });
+    },
+    getUser,
+    async getUserByEmail(email) {
+      const userId = await client.get(getUserByEmailKey(email));
+      if (!userId) return null;
+      return getUser(userId);
+    },
+    async getUserByAccount({ providerAccountId, provider }) {
+      const account = await getAccount(
+        getAccountId(providerAccountId, provider)
+      );
+      if (!account) return null;
+      return getUser(account.userId);
+    },
+
+    async updateUser(updates) {
+      const userId = updates.id as string;
+      const user = await getUser(userId);
+      return setUser(userId, { ...(user as AdapterUser), ...updates });
+    },
+    async deleteUser(userId) {
+      const user = await getUser(userId);
+      if (!user) return;
+      const accountKey = await client.get(getAccountByUserIdKey(userId));
+      const sessionKey = await client.get(getSessionByUserIdKey(userId));
+      await client.del(
+        getUserByEmailKey(user.email as string),
+        getAccountByUserIdKey(userId),
+        getSessionByUserIdKey(userId)
+      );
+      if (sessionKey) await client.del(sessionKey);
+      if (accountKey) await client.del(accountKey);
+      await client.del(getUserKey(userId));
+    },
+    async linkAccount(account) {
+      const id = getAccountId(account.providerAccountId, account.provider);
+      return setAccount(id, { ...account, id });
+    },
+    async unlinkAccount({ providerAccountId, provider }) {
+      const id = getAccountId(providerAccountId, provider);
+      await deleteAccount(id);
+    },
+    async createSession(session) {
+      const id = session.sessionToken;
+      return setSession(id, { ...session, id });
+    },
+    async getSessionAndUser(sessionToken) {
+      const id = sessionToken;
+      const session = await getSession(id);
+      if (!session) return null;
+      const user = await getUser(session.userId);
+      if (!user) return null;
+      return { session, user };
+    },
+    async updateSession(updates) {
+      const id = updates.sessionToken;
+      const session = await getSession(id);
+      if (!session) return null;
+      return setSession(id, { ...session, ...updates });
+    },
+    deleteSession,
+    async createVerificationToken(verificationToken) {
+      const id = verificationToken.identifier;
+      await setVerificationToken(id, verificationToken);
+      return verificationToken;
+    },
+    async useVerificationToken(verificationToken) {
+      const id = verificationToken.identifier;
+      const token = await getVerificationToken(id);
+      if (!token || verificationToken.token !== token.token) return null;
+      await deleteVerificationToken(id);
+      return token;
+    },
+  };
+}

--- a/packages/next/src/generators/next-auth/generator.ts
+++ b/packages/next/src/generators/next-auth/generator.ts
@@ -14,6 +14,7 @@ import { NextAuthGeneratorSchema } from './schema';
 import { installDependencies } from './utils/dependencies';
 import { createOrUpdateLocalEnv } from './utils/local-env';
 import { addAzureAdProvider } from './utils/next-auth-provider';
+import addRedisAdapter from './utils/redis-adapter';
 import { addSessionProviderToApp } from './utils/session-provider';
 
 export default async function nextAuthGenerator(
@@ -46,12 +47,24 @@ export default async function nextAuthGenerator(
         addAzureAdProvider(project, morphTree);
     }
 
-    createOrUpdateLocalEnv(project, tree, options.provider);
+    if (options.redisAdapter) {
+        await addRedisAdapter(tree, project, morphTree, {
+            envVar: options.redisEnvVar,
+            name: options.redisAdapterName,
+        });
+    }
+
+    createOrUpdateLocalEnv(project, tree, {
+        provider: options.provider,
+        redisEnvVar: options.redisAdapter ? options.redisEnvVar : undefined,
+    });
 
     await formatFiles(tree);
 
     return runTasksInSerial(
-        !options.skipPackageJson ? installDependencies(tree) : () => {},
+        !options.skipPackageJson
+            ? installDependencies(tree, { addRedis: options.redisAdapter })
+            : () => {},
         formatFilesWithEslint(options.project),
         () => {
             logger.warn(`Do not forget to update your .env.local environment variables with values.

--- a/packages/next/src/generators/next-auth/schema.d.ts
+++ b/packages/next/src/generators/next-auth/schema.d.ts
@@ -1,5 +1,8 @@
 export interface NextAuthGeneratorSchema {
     project: string;
     provider: 'none' | 'azureAd' | 'azureAdB2C';
+    redisAdapter?: boolean;
+    redisAdapterName?: string;
+    redisEnvVar?: string;
     skipPackageJson?: boolean;
 }

--- a/packages/next/src/generators/next-auth/schema.json
+++ b/packages/next/src/generators/next-auth/schema.json
@@ -30,6 +30,22 @@
                 ]
             }
         },
+        "redisAdapter": {
+            "type": "boolean",
+            "default": false,
+            "description": "Add Redis adapter to store sessions?"
+        },
+        "redisEnvVar": {
+            "type": "string",
+            "default": "REDIS_URL",
+            "description": "Name of the env var that stores connection string for Redis",
+            "x-prompt": "What is the name of the env var that stores connection string for Redis?"
+        },
+        "redisAdapterName": {
+            "type": "string",
+            "default": "next-auth-redis",
+            "description": "Name of the generated Redis adapter package"
+        },
         "skipPackageJson": {
             "type": "boolean",
             "default": false,

--- a/packages/next/src/generators/next-auth/utils/constants.ts
+++ b/packages/next/src/generators/next-auth/utils/constants.ts
@@ -1,1 +1,6 @@
 export const NEXT_AUTH_VERSION = '4.18.8';
+export const IOREDIS_VERSION = '^5.3.0';
+export const UUID_VERSION = '^9.0.0';
+export const TYPES_UUID_VERSION = '^9.0.0';
+
+export const DEFAULT_REDIS_URL = 'localhost:6379';

--- a/packages/next/src/generators/next-auth/utils/dependencies.ts
+++ b/packages/next/src/generators/next-auth/utils/dependencies.ts
@@ -1,13 +1,32 @@
 import { addDependenciesToPackageJson, Tree } from '@nrwl/devkit';
 
-import { NEXT_AUTH_VERSION } from './constants';
+import {
+    IOREDIS_VERSION,
+    NEXT_AUTH_VERSION,
+    TYPES_UUID_VERSION,
+    UUID_VERSION,
+} from './constants';
 
-export function installDependencies(tree: Tree) {
-    return addDependenciesToPackageJson(
-        tree,
-        {
-            'next-auth': NEXT_AUTH_VERSION,
-        },
-        {},
-    );
+export function installDependencies(
+    tree: Tree,
+    { addRedis }: { addRedis?: boolean } = {},
+) {
+    let dependencies: any = {
+        'next-auth': NEXT_AUTH_VERSION,
+    };
+    let devDependencies = {};
+
+    if (addRedis) {
+        dependencies = {
+            ...dependencies,
+            ioredis: IOREDIS_VERSION,
+            uuid: UUID_VERSION,
+        };
+        devDependencies = {
+            ...devDependencies,
+            '@types/uuid': TYPES_UUID_VERSION,
+        };
+    }
+
+    return addDependenciesToPackageJson(tree, dependencies, devDependencies);
 }

--- a/packages/next/src/generators/next-auth/utils/local-env.ts
+++ b/packages/next/src/generators/next-auth/utils/local-env.ts
@@ -2,6 +2,7 @@ import { joinPathFragments, ProjectConfiguration, Tree } from '@nrwl/devkit';
 import crypto from 'crypto';
 
 import { NextAuthGeneratorSchema } from '../schema';
+import { DEFAULT_REDIS_URL } from './constants';
 
 const commonEnv = [
     `NEXTAUTH_URL=http://localhost:4200`,
@@ -25,10 +26,21 @@ const providerEnv: Record<NextAuthGeneratorSchema['provider'], string[]> = {
 export function createOrUpdateLocalEnv(
     project: ProjectConfiguration,
     tree: Tree,
-    provider: NextAuthGeneratorSchema['provider'],
+    {
+        provider,
+        redisEnvVar,
+    }: {
+        provider: NextAuthGeneratorSchema['provider'];
+        redisEnvVar?: NextAuthGeneratorSchema['redisEnvVar'];
+    },
 ) {
     const localEnvPath = joinPathFragments(project.root, '.env.local');
     const envValues = [...commonEnv, ...providerEnv[provider]];
+
+    if (redisEnvVar) {
+        envValues.push(`${redisEnvVar}=${DEFAULT_REDIS_URL}`);
+    }
+
     if (!tree.exists(localEnvPath)) {
         tree.write(localEnvPath, envValues.map(env => `${env}\n`).join(''));
     } else {

--- a/packages/next/src/generators/next-auth/utils/redis-adapter.ts
+++ b/packages/next/src/generators/next-auth/utils/redis-adapter.ts
@@ -1,0 +1,129 @@
+import {
+    formatFiles,
+    generateFiles,
+    getWorkspaceLayout,
+    joinPathFragments,
+    names,
+    ProjectConfiguration,
+    readWorkspaceConfiguration,
+    Tree,
+} from '@nrwl/devkit';
+import { libraryGenerator } from '@nrwl/js';
+import path from 'path';
+import { Project, SyntaxKind } from 'ts-morph';
+
+export interface RedisAdapterOptions {
+    envVar: string;
+    name?: string;
+}
+
+function configureAdapter(
+    project: ProjectConfiguration,
+    morphTree: Project,
+    {
+        npmScope,
+        libraryName,
+        envVar,
+    }: {
+        npmScope: string;
+        libraryName: string;
+        envVar: string;
+    },
+) {
+    const nextAuthNode = morphTree.addSourceFileAtPath(
+        joinPathFragments(
+            project.root,
+            'pages',
+            'api',
+            'auth',
+            '[...nextauth].ts',
+        ),
+    );
+
+    nextAuthNode.addImportDeclaration({
+        namedImports: ['IORedisAdapter'],
+        moduleSpecifier: `${npmScope}/${libraryName}`,
+    });
+    nextAuthNode.addImportDeclaration({
+        namedImports: ['Redis'],
+        moduleSpecifier: 'ioredis',
+    });
+
+    const callExpression = nextAuthNode
+        .getDescendantsOfKind(SyntaxKind.CallExpression)
+        .find(
+            d =>
+                d.getFirstChildByKind(SyntaxKind.Identifier).getText() ===
+                'NextAuth',
+        );
+
+    if (!callExpression) {
+        throw new Error('Unable to find the NextAuth implementation function.');
+    }
+
+    const config = callExpression.getFirstChildByKind(
+        SyntaxKind.ObjectLiteralExpression,
+    );
+
+    const adapterProperty = config
+        .getDescendantsOfKind(SyntaxKind.PropertyAssignment)
+        .find(
+            c =>
+                c.getFirstDescendantByKind(SyntaxKind.Identifier)?.getText() ===
+                'adapter',
+        );
+
+    if (adapterProperty) {
+        adapterProperty.remove();
+    }
+    config.addPropertyAssignment({
+        name: 'adapter',
+        initializer: `IORedisAdapter(new Redis(process.env.${envVar}))`,
+    });
+
+    nextAuthNode.saveSync();
+}
+
+export default async function addRedisAdapter(
+    tree: Tree,
+    project: ProjectConfiguration,
+    morphTree: Project,
+    { envVar, name: nameParameter }: RedisAdapterOptions,
+) {
+    const { npmScope } = readWorkspaceConfiguration(tree);
+    const name = nameParameter || 'next-auth-redis';
+
+    const libraryName = names(name).fileName;
+    const projectDirectory = libraryName;
+    const projectRoot = `${
+        getWorkspaceLayout(tree).libsDir
+    }/${projectDirectory}`;
+
+    // generate the lib package
+    await libraryGenerator(tree, {
+        name: libraryName,
+    });
+    // delete the default generated lib folder
+    const libraryDirectory = path.join(projectRoot, 'src');
+    tree.delete(path.join(libraryDirectory, 'lib'));
+    tree.delete(path.join(libraryDirectory, 'index.ts'));
+
+    // add files
+    generateFiles(
+        tree,
+        path.join(__dirname, '..', 'files-redis'),
+        projectRoot,
+        {
+            envVar,
+            template: '',
+        },
+    );
+
+    configureAdapter(project, morphTree, {
+        npmScope,
+        libraryName,
+        envVar,
+    });
+
+    await formatFiles(tree);
+}


### PR DESCRIPTION
```
nx generate @ensono-stacks/next:next-auth --project=[next-app-name] --redisAdapter
```

To add next-auth to your next app and also generate a Redis adapter to store session data.

Other options:

- `--redisEnvVar value` - set a custom env var name to store Redis connection info. Default `REDIS_URL`.
- `--redisAdapterName value` - set a custom name for the generated library. Default `next-auth-redis`.

The adapter is based off [this example](https://github.com/quanhua92/next-auth-ioredis-adapter-example/blob/main/lib/IORedisAdapter.ts) which in turn was based off the official [Upstash Redis Adapter](https://github.com/nextauthjs/next-auth/blob/main/packages/adapter-upstash-redis/src/index.ts) .

The adapter tests are based off the [next-auth adapter tests](https://github.com/nextauthjs/next-auth/blob/main/packages/adapter-test/index.ts) which, sadly, aren't published on npm, so I had to copy/paste them. They are being used by the [Upstash Redis Adapter tests](https://github.com/nextauthjs/next-auth/blob/main/packages/adapter-upstash-redis/tests/index.test.ts) too.

Curiously there is no official Redis adapter, nor I could find any unofficial one (except for the example one, which isn't published as a library). But maybe that's good, it means that consumers of our generator will be able to fully adjust to their needs.

Also adds `ioredis` and `uuid` to project deps and `@types/uuid` to project dev deps.