### PR TITLE
fix(next): eslint errors from @nrwl/next

### DIFF
--- a/packages/next/src/generators/init/generator.ts
+++ b/packages/next/src/generators/init/generator.ts
@@ -14,6 +14,7 @@ import infrastructureGenerator from '../infrastructure/generator';
 import { NextGeneratorSchema } from './schema';
 import addCustomTestConfig from './utils/add-custom-test-config';
 import { addEslint } from './utils/eslint';
+import { eslintFix } from './utils/eslint-fix';
 import updateTsConfig from './utils/tsconfig';
 
 export default async function initGenerator(
@@ -61,6 +62,8 @@ export default async function initGenerator(
         project,
         path.join(project.sourceRoot, 'tsconfig.spec.json'),
     );
+
+    eslintFix(project, tree);
 
     await formatFiles(tree);
 

--- a/packages/next/src/generators/init/utils/eslint-fix.ts
+++ b/packages/next/src/generators/init/utils/eslint-fix.ts
@@ -8,16 +8,6 @@ import { SyntaxKind } from 'ts-morph';
 export function eslintFix(project: ProjectConfiguration, tree: Tree) {
     const morphTree = tsMorphTree(tree);
 
-    // Specify the rules you want to disable  unicorn/no-abusive-eslint-disable
-    const jestConfigNode = morphTree.addSourceFileAtPath(
-        joinPathFragments(project.root, 'jest.config.ts'),
-    );
-    jestConfigNode
-        .getStatementsWithComments()
-        .find(node => node.getText() === '/* eslint-disable */')
-        ?.remove();
-    jestConfigNode.saveSync();
-
     // Using exported name 'Index' as identifier for default export  import/no-named-as-default
     const indexSpecNode = morphTree.addSourceFileAtPath(
         joinPathFragments(project.root, 'specs', 'index.spec.tsx'),

--- a/packages/next/src/generators/init/utils/eslint-fix.ts
+++ b/packages/next/src/generators/init/utils/eslint-fix.ts
@@ -1,0 +1,36 @@
+import { tsMorphTree } from '@ensono-stacks/core';
+import { joinPathFragments, ProjectConfiguration, Tree } from '@nrwl/devkit';
+import { SyntaxKind } from 'ts-morph';
+
+/**
+ * Fixes eslint errors from @nrwl/next incompatible with our config.
+ */
+export function eslintFix(project: ProjectConfiguration, tree: Tree) {
+    const morphTree = tsMorphTree(tree);
+
+    // Specify the rules you want to disable  unicorn/no-abusive-eslint-disable
+    const jestConfigNode = morphTree.addSourceFileAtPath(
+        joinPathFragments(project.root, 'jest.config.ts'),
+    );
+    jestConfigNode
+        .getStatementsWithComments()
+        .find(node => node.getText() === '/* eslint-disable */')
+        ?.remove();
+    jestConfigNode.saveSync();
+
+    // Using exported name 'Index' as identifier for default export  import/no-named-as-default
+    const indexSpecNode = morphTree.addSourceFileAtPath(
+        joinPathFragments(project.root, 'specs', 'index.spec.tsx'),
+    );
+    const imports = indexSpecNode.getDescendantsOfKind(
+        SyntaxKind.ImportDeclaration,
+    );
+    const indexImport = imports.find(
+        node => node.getModuleSpecifierValue() === '../pages/index',
+    );
+    if (indexImport) {
+        indexImport.removeDefaultImport();
+        indexImport.addNamedImport('Index');
+        indexSpecNode.saveSync();
+    }
+}

--- a/packages/workspace/src/generators/init/utils/eslint.ts
+++ b/packages/workspace/src/generators/init/utils/eslint.ts
@@ -144,6 +144,12 @@ function stacksEslintConfig(tree: Tree): Linter.Config {
                 parser: 'jsonc-eslint-parser',
                 rules: {},
             },
+            {
+                files: 'jest.config.ts',
+                rules: {
+                    'unicorn/no-abusive-eslint-disable': 'off',
+                },
+            },
         ],
     };
 }


### PR DESCRIPTION
It looks like the code generated by `@nrwl/next` is not compatible with our eslint config :P We have to manually fix it, unfortunately :(

```
> nx run next-app-2:lint --fix


Linting "next-app-2"...

C:\Users\dphillips\Documents\code\stacks-testing-folder\0-3-3-next-workspace\apps\next-app-2\jest.config.ts
  1:0  error  Specify the rules you want to disable  unicorn/no-abusive-eslint-disable

C:\Users\dphillips\Documents\code\stacks-testing-folder\0-3-3-next-workspace\apps\next-app-2\specs\index.spec.tsx
  4:8  warning  Using exported name 'Index' as identifier for default export  import/no-named-as-default

✖ 2 problems (1 error, 1 warning)
```