### PR TITLE
fix(create): remove create-stacks-workspace defaults previously added

### DIFF
--- a/e2e/create-e2e/tests/create.spec.ts
+++ b/e2e/create-e2e/tests/create.spec.ts
@@ -112,7 +112,6 @@ describe('create', () => {
                 },
                 vcs: {
                     type: 'github',
-                    url: 'remote.git',
                 },
             }),
         );

--- a/packages/create/bin/create-stacks-workspace.ts
+++ b/packages/create/bin/create-stacks-workspace.ts
@@ -270,7 +270,6 @@ export const commandsObject: yargs.Argv<CreateStacksArguments> = yargs
                 .option('appName', {
                     describe: chalk.dim`The name of the application when a preset with pregenerated app is selected`,
                     type: 'string',
-                    default: 'myapp',
                 })
                 .option('nxVersion', {
                     describe: chalk.dim`Set the version of Nx you want installed`,
@@ -321,32 +320,26 @@ export const commandsObject: yargs.Argv<CreateStacksArguments> = yargs
                 .option('business.company', {
                     describe: chalk.dim`Company Name`,
                     type: 'string',
-                    default: 'Amido',
                 })
                 .option('business.domain', {
                     describe: chalk.dim`Company Scope or area`,
                     type: 'string',
-                    default: 'stacks',
                 })
                 .option('business.component', {
                     describe: chalk.dim`Company component being worked on`,
                     type: 'string',
-                    default: 'nx',
                 })
                 .option('domain.internal', {
                     describe: chalk.dim`Internal domain for nonprod resources`,
                     type: 'string',
-                    default: 'test.com',
                 })
                 .option('domain.external', {
                     describe: chalk.dim`External domain for prod resources`,
                     type: 'string',
-                    default: 'test.dev',
                 })
                 .option('terraform.group', {
                     describe: chalk.dim`Terraform state group name`,
                     type: 'string',
-                    default: 'terraform-group',
                 })
                 .option('terraform.container', {
                     describe: chalk.dim`Terraform storage container name`,
@@ -355,23 +348,19 @@ export const commandsObject: yargs.Argv<CreateStacksArguments> = yargs
                 .option('terraform.storage', {
                     describe: chalk.dim`Terraform storage name`,
                     type: 'string',
-                    default: 'terraform-storage',
                 })
                 .option('terraform.container', {
                     describe: chalk.dim`Terraform container name`,
                     type: 'string',
-                    default: 'terraform-container',
                 })
                 .option('vcs.type', {
                     describe: chalk.dim`Version control provider`,
                     choices: ['azdo', 'github'],
                     type: 'string',
-                    default: 'github',
                 })
                 .option('vcs.url', {
                     describe: chalk.dim`Version control remote url`,
                     type: 'string',
-                    default: 'remote.git',
                 }),
         async (argv: yargs.ArgumentsCamelCase<CreateStacksArguments>) => {
             return main(argv).catch(console.log);


### PR DESCRIPTION
To fix: https://amido-dev.visualstudio.com/Amido-Stacks/_workitems/edit/5467

Issue: As part of [this PR](https://github.com/amido/stacks-nx-plugins/pull/51/files), default values were added for all the create-nx-workspace options that didn't have one already. This was to work around an issue that prevented running `create-stacks-workspaces` when those values weren't present. That issue has now been fixed, so the default values should no longer be necessary.

As a side effect of those default values, the `appName` was not gathered as an interactive option. This change reverts the default values and brings back the interactive `appName` option.