### PR TITLE
fix(next): infra files formatting errors

### DIFF
--- a/packages/next/src/generators/infrastructure/files/azure/build/terraform/variables.tf
+++ b/packages/next/src/generators/infrastructure/files/azure/build/terraform/variables.tf
@@ -1,9 +1,9 @@
 variable "dns_a_record_name" {
-  type    = string
+  type = string
 }
 
 variable "dns_a_record_records" {
-  type    = list(string)
+  type = list(string)
 }
 
 variable "dns_a_record_ttl" {
@@ -12,9 +12,9 @@ variable "dns_a_record_ttl" {
 }
 
 variable "dns_zone" {
-  type    = string
+  type = string
 }
 
 variable "dns_zone_rg" {
-  type    = string
+  type = string
 }

--- a/packages/next/src/generators/infrastructure/files/common/build/helm/templates/service.yaml
+++ b/packages/next/src/generators/infrastructure/files/common/build/helm/templates/service.yaml
@@ -1,15 +1,15 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "<%= projectName %>.fullname" . }}
-  namespace: {{ .Values.namespace }}
-  labels: {{- include "<%= projectName %>.labels" . | nindent 4 }}
+    name: { { include "<%= projectName %>.fullname" . } }
+    namespace: { { .Values.namespace } }
+    labels: { { - include "<%= projectName %>.labels" . | nindent 4 } }
 spec:
-  type: {{ .Values.service.type }}
-  ports:
-    - port: {{ .Values.service.port }}
-      targetPort: http
-      protocol: TCP
-      name: http
-  selector:
-    {{- include "<%= projectName %>.selectorLabels" . | nindent 4 }}
+    type: { { .Values.service.type } }
+    ports:
+        - port: { { .Values.service.port } }
+          targetPort: http
+          protocol: TCP
+          name: http
+    selector:
+        { { - include "<%= projectName %>.selectorLabels" . | nindent 4 } }

--- a/packages/next/src/generators/infrastructure/files/common/build/helm/templates/service.yaml
+++ b/packages/next/src/generators/infrastructure/files/common/build/helm/templates/service.yaml
@@ -1,15 +1,15 @@
 apiVersion: v1
 kind: Service
 metadata:
-    name: { { include "<%= projectName %>.fullname" . } }
-    namespace: { { .Values.namespace } }
-    labels: { { - include "<%= projectName %>.labels" . | nindent 4 } }
+  name: {{ include "<%= projectName %>.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels: {{- include "<%= projectName %>.labels" . | nindent 4 }}
 spec:
-    type: { { .Values.service.type } }
-    ports:
-        - port: { { .Values.service.port } }
-          targetPort: http
-          protocol: TCP
-          name: http
-    selector:
-        { { - include "<%= projectName %>.selectorLabels" . | nindent 4 } }
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "<%= projectName %>.selectorLabels" . | nindent 4 }}

--- a/packages/next/src/generators/infrastructure/utils/terraform.ts
+++ b/packages/next/src/generators/infrastructure/utils/terraform.ts
@@ -61,7 +61,7 @@ export function addTerraform(
         options: {
             commands: [
                 {
-                    command: 'terraform fmt -diff',
+                    command: 'terraform fmt -check -diff',
                     forwardAllArgs: false,
                 },
             ],

--- a/packages/next/src/generators/infrastructure/utils/terraform.ts
+++ b/packages/next/src/generators/infrastructure/utils/terraform.ts
@@ -61,7 +61,7 @@ export function addTerraform(
         options: {
             commands: [
                 {
-                    command: 'terraform fmt -check -diff',
+                    command: 'terraform fmt -diff',
                     forwardAllArgs: false,
                 },
             ],


### PR DESCRIPTION
Fixes issues 1 and 3 from https://amido-dev.visualstudio.com/Amido-Stacks/_workitems/edit/5452

1: Fix formatting of `service.yaml` file to prevent error on lint. 
3: Remove `-check` flag from `terraform-fmt` command, so that any formatting problems are automatically fixed instead of exiting out. Also fix formatting of `variables.tf` file.