### PR TITLE
fix(azure-react): adds check to throw error if connectionString is empty

### DIFF
--- a/packages/azure-react/src/generators/app-insights-web/generator.spec.ts
+++ b/packages/azure-react/src/generators/app-insights-web/generator.spec.ts
@@ -56,4 +56,13 @@ describe('azure-react generator', () => {
             ]),
         );
     });
+
+    it('should throw an error if connection string is empty', async () => {
+        await expect(() =>
+            generator(tree, {
+                ...options,
+                connectionString: '',
+            }),
+        ).rejects.toThrowError('connectionString cannot be empty.');
+    });
 });

--- a/packages/azure-react/src/generators/app-insights-web/generator.ts
+++ b/packages/azure-react/src/generators/app-insights-web/generator.ts
@@ -80,6 +80,10 @@ export default async function appInsightsWebGenerator(
     tree: Tree,
     options: AppInsightsWebGeneratorSchema,
 ) {
+    if (!options.connectionString) {
+        throw new Error('connectionString cannot be empty.');
+    }
+
     // Normalize options
     const normalizedOptions = normalizeOptions(tree, options);
 

--- a/packages/azure-react/src/generators/app-insights-web/schema.json
+++ b/packages/azure-react/src/generators/app-insights-web/schema.json
@@ -24,7 +24,7 @@
         "directory": {
             "type": "string",
             "description": "A directory where the lib is placed.",
-            "alias": "d"
+            "alias": "dir"
         },
         "importPath": {
             "type": "string",


### PR DESCRIPTION
[5471](https://dev.azure.com/amido-dev/Amido-Stacks/_workitems/edit/5471)

- throws error if connectionString is empty
- reuse --dir for directory alias