### PR TITLE
fix(next-init-infrastructure): add infrastructure related targets to project targets in init generator

### DIFF
--- a/packages/common/core/src/utils/ignoreEntry.ts
+++ b/packages/common/core/src/utils/ignoreEntry.ts
@@ -22,6 +22,7 @@ export function addIgnoreEntry(
     }
 
     // split the file to subsets based on empty lines
+    const fileEntries = content.split('\n');
     const subsets = content.split('\n\n');
 
     entries.forEach(entry => {
@@ -29,7 +30,10 @@ export function addIgnoreEntry(
             const subsetIndex = subsets.findIndex(subset =>
                 subset.includes(`# ${comment}`),
             );
-            subsets[subsetIndex] = `${subsets[subsetIndex]}\n${entry}`;
+            const duplicate = fileEntries.includes(entry);
+            subsets[subsetIndex] = duplicate
+                ? subsets[subsetIndex]
+                : `${subsets[subsetIndex]}\n${entry}`;
         }
     });
 

--- a/packages/common/core/src/utils/ignoreEntry.ts
+++ b/packages/common/core/src/utils/ignoreEntry.ts
@@ -30,8 +30,8 @@ export function addIgnoreEntry(
             const subsetIndex = subsets.findIndex(subset =>
                 subset.includes(`# ${comment}`),
             );
-            const duplicate = fileEntries.includes(entry);
-            subsets[subsetIndex] = duplicate
+
+            subsets[subsetIndex] = fileEntries.includes(entry)
                 ? subsets[subsetIndex]
                 : `${subsets[subsetIndex]}\n${entry}`;
         }

--- a/packages/next/src/generators/infrastructure/utils/add-infrastructure.ts
+++ b/packages/next/src/generators/infrastructure/utils/add-infrastructure.ts
@@ -17,8 +17,8 @@ export function addInfrastructure(
     options: NextGeneratorSchema,
 ) {
     const tasks: GeneratorCallback[] = [
-        addCommon(tree, project),
-        addTerraform(tree, project, options),
+        addCommon(tree, options),
+        addTerraform(tree, options),
     ];
 
     addIgnoreEntry(tree, '.gitignore', 'Terraform', [

--- a/packages/next/src/generators/infrastructure/utils/common.ts
+++ b/packages/next/src/generators/infrastructure/utils/common.ts
@@ -6,7 +6,7 @@ import {
     offsetFromRoot,
     updateJson,
     updateProjectConfiguration,
-    ProjectConfiguration,
+    readProjectConfiguration,
     Tree,
 } from '@nrwl/devkit';
 import { paramCase } from 'change-case';
@@ -17,6 +17,7 @@ import {
     NXTOOLS_NX_CONTAINER_VERSION,
     NXTOOLS_NX_METADATA_VERSION,
 } from '../../../utils/constants';
+import { NextGeneratorSchema } from '../schema';
 
 function addCommonInfrastructureDependencies(tree: Tree) {
     return addDependenciesToPackageJson(
@@ -34,8 +35,9 @@ export function setPort(project) {
     return project.targets?.serve.options.port || 4200;
 }
 
-export function addCommon(tree: Tree, project: ProjectConfiguration) {
+export function addCommon(tree: Tree, options: NextGeneratorSchema) {
     const stacksConfig = readStacksConfig(tree);
+    const project = readProjectConfiguration(tree, options.project);
 
     const customServer =
         project.targets?.['build-custom-server']?.options?.main;

--- a/packages/next/src/generators/init/generator.spec.ts
+++ b/packages/next/src/generators/init/generator.spec.ts
@@ -144,6 +144,23 @@ describe('next install generator', () => {
                 }),
             );
         });
+
+        it('should add infrastucture configurations to project.json when infrastructure option is set to true', async () => {
+            await generator(tree, { ...options, infra: true });
+
+            const projectConfig = readJson(tree, 'next-app/project.json');
+            expect(projectConfig.targets).toHaveProperty('terraform-apply');
+            expect(projectConfig.targets).toHaveProperty('terraform-plan');
+            expect(projectConfig.targets).toHaveProperty('terraform-validate');
+            expect(projectConfig.targets).toHaveProperty('terraform-init');
+            expect(projectConfig.targets).toHaveProperty('terraform-fmt');
+            expect(projectConfig.targets).toHaveProperty('github');
+            expect(projectConfig.targets).toHaveProperty('helm-push');
+            expect(projectConfig.targets).toHaveProperty('helm-package');
+            expect(projectConfig.targets).toHaveProperty('helm-test');
+            expect(projectConfig.targets).toHaveProperty('helm-lint');
+            expect(projectConfig.targets).toHaveProperty('helm-upgrade');
+        });
     });
 
     describe('eslint', () => {

--- a/packages/next/src/generators/init/generator.ts
+++ b/packages/next/src/generators/init/generator.ts
@@ -1,12 +1,12 @@
 import {
+    formatFiles,
     formatFilesWithEslint,
     addCustomTestConfig,
 } from '@ensono-stacks/core';
 import {
-    formatFiles,
     GeneratorCallback,
+    joinPathFragments,
     readProjectConfiguration,
-    updateJson,
     Tree,
     updateProjectConfiguration,
 } from '@nrwl/devkit';
@@ -83,7 +83,10 @@ export default async function initGenerator(
 
     eslintFix(project, tree);
 
-    await formatFiles(tree);
+    // exclude helm yaml files from initial format when generating the files
+    await formatFiles(tree, [
+        joinPathFragments(project.root, 'build', 'helm', '**', '*.yaml'),
+    ]);
 
     return runTasksInSerial(...tasks);
 }

--- a/packages/next/src/generators/init/generator.ts
+++ b/packages/next/src/generators/init/generator.ts
@@ -62,7 +62,12 @@ export default async function initGenerator(
         },
     };
 
-    await addCustomTestConfig(tree, project, project.name, ciCoverageConfig);
+    await addCustomTestConfig(
+        tree,
+        readProjectConfiguration(tree, options.project),
+        project.name,
+        ciCoverageConfig,
+    );
 
     tasks.push(formatFilesWithEslint(options.project));
 


### PR DESCRIPTION
project.json is updated in several different areas throughout the init generator.
It's updated in:
    generator.ts -> updateProjectConfiguration()
    generator.ts -> addCustomTestConfig()
    generator.ts -> addInfrastructure() -> addCommon()
    generator.ts -> addInfrastructure() -> addTerraform()

after updating the project.json, the new updated configurations must be fetched and used to merge amended project configurations within each function that alters the project configuration