### PR TITLE
fix(playwright): update project name passed in create script

### DIFF
--- a/packages/create/bin/dependencies.ts
+++ b/packages/create/bin/dependencies.ts
@@ -72,7 +72,7 @@ export function getGeneratorsToRun(
 
     if (argv.e2eTestRunner === E2eTestRunner.Playwright) {
         generators.push(
-            `@ensono-stacks/playwright:init --project=${argv.appName}-e2e`,
+            `@ensono-stacks/playwright:init --project=${argv.appName}`,
         );
 
         console.log('\n');

--- a/packages/playwright/src/generators/init/generator.spec.ts
+++ b/packages/playwright/src/generators/init/generator.spec.ts
@@ -22,7 +22,7 @@ jest.mock('@nrwl/devkit', () => {
                         'test',
                         {
                             root: '',
-                            sourceRoot: `${projectNameE2E}/src`,
+                            sourceRoot: `${projectName}`,
                             name: 'test',
                         },
                     ],

--- a/packages/playwright/src/generators/init/generator.ts
+++ b/packages/playwright/src/generators/init/generator.ts
@@ -1,7 +1,6 @@
 import { addIgnoreEntry, tsMorphTree } from '@ensono-stacks/core';
 import initPlaywrightGenerator from '@mands/nx-playwright/src/generators/project/generator';
 import { NxPlaywrightGeneratorSchema } from '@mands/nx-playwright/src/generators/project/schema-types';
-import { PackageRunner } from '@mands/nx-playwright/src/types';
 import {
     formatFiles,
     generateFiles,
@@ -43,10 +42,12 @@ function addFiles(tree: Tree, source: string, options: NormalizedSchema) {
         template: '',
     };
 
+    const projectRootE2E = `${options.projectRoot}-e2e/src`;
+
     generateFiles(
         tree,
         path.join(__dirname, source),
-        options.projectRoot,
+        projectRootE2E,
         templateOptions,
     );
 }

--- a/packages/playwright/src/generators/init/generator.ts
+++ b/packages/playwright/src/generators/init/generator.ts
@@ -59,6 +59,7 @@ function updateDependencies(tree) {
         {
             playwright: '*',
             '@playwright/test': '*',
+            '@mands/nx-playwright': '*',
         },
     );
 }


### PR DESCRIPTION
- removes passing `e2e` in the create script as this is added inside the playwright init generator and the passed value needs to be an existing project
- updates unit test
- adds @mands/nx-playwright to devDep for new project (executor e2e purposes)