### PR TITLE
fix(rest-client): remove version from type interfaces

### DIFF
--- a/packages/rest-client/src/generators/bump-version/schema.json
+++ b/packages/rest-client/src/generators/bump-version/schema.json
@@ -9,7 +9,7 @@
         "name": {
             "type": "string",
             "description": "The endpoint you want to bump.",
-            "x-prompt": "Which endpoint you want to bump?",
+            "x-prompt": "Which endpoint do you want to bump?",
             "$default": {
                 "$source": "argv",
                 "index": 0

--- a/packages/rest-client/src/generators/bump-version/schema.json
+++ b/packages/rest-client/src/generators/bump-version/schema.json
@@ -8,8 +8,8 @@
     "properties": {
         "name": {
             "type": "string",
-            "description": "The endpoint name you want to bump.",
-            "x-prompt": "What is the name of the endpoint you want to bump?",
+            "description": "The endpoint you want to bump.",
+            "x-prompt": "Which endpoint you want to bump?",
             "$default": {
                 "$source": "argv",
                 "index": 0
@@ -27,5 +27,5 @@
             "pattern": "^\\d+$"
         }
     },
-    "required": ["name"]
+    "required": ["name", "directory"]
 }

--- a/packages/rest-client/src/generators/client-endpoint/files/src/index.test.ts__template__
+++ b/packages/rest-client/src/generators/client-endpoint/files/src/index.test.ts__template__
@@ -1,6 +1,6 @@
 // TODO: Write generated tests
 
-describe('<%= className %> endpoint', () => {
+describe('<%= endpointName %> endpoint', () => {
     it('should generate the right methods', () => {
         expect(true).toBeTruthy();
     });

--- a/packages/rest-client/src/generators/client-endpoint/files/src/index.ts__template__
+++ b/packages/rest-client/src/generators/client-endpoint/files/src/index.ts__template__
@@ -1,59 +1,59 @@
 import httpClient, { RequestConfig, Response } from '<%= httpClient %>';
 
-import { <%= className %>, <%= className %>Data } from './index.types';
+import { <%= endpointName %>, <%= endpointName %>Data } from './index.types';
 
 const API_ENDPOINT = `${process.env.<%= envVar %>}/<%= endpointName %>/v<%= endpointVersion %>`;
-
 <% if (methods.includes('get')) { %>
-export const get<%= fnSuffix %> = async (config: RequestConfig) => 
-    httpClient.get<<%= className %>>(API_ENDPOINT, config)
-<% } %>
 
+export const get<%= endpointName %> = async (config: RequestConfig) => 
+    httpClient.get<<%= endpointName %>>(API_ENDPOINT, config)
+<% } %>
 <% if (methods.includes('delete')) { %>
-export const delete<%= fnSuffix %> = async (config: RequestConfig) => 
-    httpClient.delete<<%= className %>>(API_ENDPOINT, config)
-<% } %>
 
+export const delete<%= endpointName %> = async (config: RequestConfig) => 
+    httpClient.delete<<%= endpointName %>>(API_ENDPOINT, config)
+<% } %>
 <% if (methods.includes('head')) { %>
-export const head<%= fnSuffix %> = async (config: RequestConfig) => 
-    httpClient.head<<%= className %>>(API_ENDPOINT, config)
-<% } %>
 
+export const head<%= endpointName %> = async (config: RequestConfig) => 
+    httpClient.head<<%= endpointName %>>(API_ENDPOINT, config)
+<% } %>
 <% if (methods.includes('options')) { %>
-export const options<%= fnSuffix %> = async (config: RequestConfig) => 
-    httpClient.options<<%= className %>>(API_ENDPOINT, config)
-<% } %>
 
+export const options<%= endpointName %> = async (config: RequestConfig) => 
+    httpClient.options<<%= endpointName %>>(API_ENDPOINT, config)
+<% } %>
 <% if (methods.includes('post')) { %>
-export const post<%= fnSuffix %> = async (
-    data: <%= className %>Data,
+
+export const post<%= endpointName %> = async (
+    data: <%= endpointName %>Data,
     config: RequestConfig
 ) => 
-    httpClient.post<<%= className %>, Response<<%= className %>>, <%= className %>Data>(
+    httpClient.post<<%= endpointName %>, Response<<%= endpointName %>>, <%= endpointName %>Data>(
         API_ENDPOINT,
         data,
         config
     );
 <% } %>
-
 <% if (methods.includes('put')) { %>
-export const put<%= fnSuffix %> = async (
-    data: <%= className %>Data,
+
+export const put<%= endpointName %> = async (
+    data: <%= endpointName %>Data,
     config: RequestConfig
 ) => 
-    httpClient.put<<%= className %>, Response<<%= className %>>, <%= className %>Data>(
+    httpClient.put<<%= endpointName %>, Response<<%= endpointName %>>, <%= endpointName %>Data>(
         API_ENDPOINT,
         data,
         config
     );
 <% } %>
-
 <% if (methods.includes('patch')) { %>
-export const patch<%= fnSuffix %> = async (
-    data: Partial<<%= className %>Data>,
+
+export const patch<%= endpointName %> = async (
+    data: Partial<<%= endpointName %>Data>,
     config: RequestConfig
 ) => 
-    httpClient.patch<<%= className %>, Response<<%= className %>>, <%= className %>Data>(
+    httpClient.patch<<%= endpointName %>, Response<<%= endpointName %>>, <%= endpointName %>Data>(
         API_ENDPOINT,
         data,
         config

--- a/packages/rest-client/src/generators/client-endpoint/files/src/index.types.ts__template__
+++ b/packages/rest-client/src/generators/client-endpoint/files/src/index.types.ts__template__
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-export interface <%= className %> {
+export interface <%= endpointName %> {
 
 }
 
-export interface <%= className %>Data {
+export interface <%= endpointName %>Data {
 
 }

--- a/packages/rest-client/src/generators/client-endpoint/generator.ts
+++ b/packages/rest-client/src/generators/client-endpoint/generator.ts
@@ -27,8 +27,7 @@ const VALID_METHODS = [
 function addFiles(tree: Tree, options: NormalizedSchema) {
     const templateOptions = {
         ...options,
-        ...names(options.name),
-        fnSuffix: names(options.endpointName).className,
+        endpointName: names(options.endpointName).className,
         template: '',
     };
 


### PR DESCRIPTION
- change unnecessarily complicated naming from type interfaces.
- fix the required values in the bump version generator schema