### PR TITLE
fix(rest-client): linting and generator config

### DIFF
--- a/e2e/rest-client-e2e/tests/rest-client.spec.ts
+++ b/e2e/rest-client-e2e/tests/rest-client.spec.ts
@@ -90,7 +90,7 @@ describe('rest-client e2e', () => {
 
         it('should copy the existing endpoint and bump the version', async () => {
             await runNxCommand(
-                `generate @ensono-stacks/rest-client:bump-version endpoints-${endpoint}-v1 --endpointVersion=3 --no-interactive`,
+                `generate @ensono-stacks/rest-client:bump-version --name endpoints-${endpoint}-v1 --endpointVersion=3 --no-interactive`,
             );
 
             expect(() =>
@@ -129,7 +129,7 @@ describe('rest-client e2e', () => {
 
         it('should run the generated tests without failure', async () => {
             const result = await runNxCommandAsync(
-                `test endpoints-test-endpoint-v3`,
+                `test endpoints-${endpoint}-v3`,
             );
 
             expect(result.stderr).not.toEqual(expect.stringContaining('FAIL'));

--- a/e2e/rest-client-e2e/tests/rest-client.spec.ts
+++ b/e2e/rest-client-e2e/tests/rest-client.spec.ts
@@ -63,11 +63,16 @@ describe('rest-client e2e', () => {
             const expectedImportName = `@proj/endpoints/${endpoint}/v1`;
 
             const tsConfig = readJson('tsconfig.base.json');
-            expect(tsConfig.compilerOptions.paths).toHaveProperty(expectedImportName, [`libs/endpoints/${endpoint}/v1/src/index.ts`]);
+            expect(tsConfig.compilerOptions.paths).toHaveProperty(
+                expectedImportName,
+                [`libs/endpoints/${endpoint}/v1/src/index.ts`],
+            );
         }, 120000);
 
         it('should run the generated tests without failure', async () => {
-            const result = await runNxCommandAsync(`test endpoints-${endpoint}-v1`);
+            const result = await runNxCommandAsync(
+                `test endpoints-${endpoint}-v1`,
+            );
 
             expect(result.stderr).not.toEqual(expect.stringContaining('FAIL'));
         });
@@ -75,6 +80,7 @@ describe('rest-client e2e', () => {
 
     describe('bump-version', () => {
         const endpoint = uniq('test-endpoint');
+        const endpointWithDirectory = `endpoints/${endpoint}`;
 
         beforeAll(async () => {
             await runNxCommand(
@@ -84,39 +90,47 @@ describe('rest-client e2e', () => {
 
         it('should copy the existing endpoint and bump the version', async () => {
             await runNxCommand(
-                `generate @ensono-stacks/rest-client:bump-version ${endpoint} --directory=endpoints --endpointVersion=3 --no-interactive`,
+                `generate @ensono-stacks/rest-client:bump-version endpoints-${endpoint}-v1 --endpointVersion=3 --no-interactive`,
             );
 
             expect(() =>
                 checkFilesExist(
-                    `libs/endpoints/${endpoint}/v1/src/index.ts`,
-                    `libs/endpoints/${endpoint}/v1/src/index.test.ts`,
-                    `libs/endpoints/${endpoint}/v1/src/index.types.ts`,
-                    `libs/endpoints/${endpoint}/v1/project.json`,
-                    `libs/endpoints/${endpoint}/v1/tsconfig.json`,
+                    `libs/${endpointWithDirectory}/v1/src/index.ts`,
+                    `libs/${endpointWithDirectory}/v1/src/index.test.ts`,
+                    `libs/${endpointWithDirectory}/v1/src/index.types.ts`,
+                    `libs/${endpointWithDirectory}/v1/project.json`,
+                    `libs/${endpointWithDirectory}/v1/tsconfig.json`,
                 ),
             ).not.toThrow();
 
             expect(() =>
                 checkFilesExist(
-                    `libs/endpoints/${endpoint}/v3/src/index.ts`,
-                    `libs/endpoints/${endpoint}/v3/src/index.test.ts`,
-                    `libs/endpoints/${endpoint}/v3/src/index.types.ts`,
-                    `libs/endpoints/${endpoint}/v3/project.json`,
-                    `libs/endpoints/${endpoint}/v3/tsconfig.json`,
+                    `libs/${endpointWithDirectory}/v3/src/index.ts`,
+                    `libs/${endpointWithDirectory}/v3/src/index.test.ts`,
+                    `libs/${endpointWithDirectory}/v3/src/index.types.ts`,
+                    `libs/${endpointWithDirectory}/v3/project.json`,
+                    `libs/${endpointWithDirectory}/v3/tsconfig.json`,
                 ),
             ).not.toThrow();
 
-            const expectedImportNameV1 = `@proj/endpoints/${endpoint}/v1`;
-            const expectedImportNameV3 = `@proj/endpoints/${endpoint}/v3`;
+            const expectedImportNameV1 = `@proj/${endpointWithDirectory}/v1`;
+            const expectedImportNameV3 = `@proj/${endpointWithDirectory}/v3`;
 
             const tsConfig = readJson('tsconfig.base.json');
-            expect(tsConfig.compilerOptions.paths).toHaveProperty(expectedImportNameV1, [`libs/endpoints/${endpoint}/v1/src/index.ts`]);
-            expect(tsConfig.compilerOptions.paths).toHaveProperty(expectedImportNameV3, [`libs/endpoints/${endpoint}/v3/src/index.ts`]);
+            expect(tsConfig.compilerOptions.paths).toHaveProperty(
+                expectedImportNameV1,
+                [`libs/${endpointWithDirectory}/v1/src/index.ts`],
+            );
+            expect(tsConfig.compilerOptions.paths).toHaveProperty(
+                expectedImportNameV3,
+                [`libs/${endpointWithDirectory}/v3/src/index.ts`],
+            );
         }, 120000);
 
         it('should run the generated tests without failure', async () => {
-            const result = await runNxCommandAsync(`test endpoints-${endpoint}-v3`);
+            const result = await runNxCommandAsync(
+                `test endpoints-test-endpoint-v3`,
+            );
 
             expect(result.stderr).not.toEqual(expect.stringContaining('FAIL'));
         });

--- a/packages/common/core/src/lib/normalize-options.ts
+++ b/packages/common/core/src/lib/normalize-options.ts
@@ -39,9 +39,8 @@ export function normalizeOptions<TSchema extends BaseSchema>(
         projectDirectory,
     );
 
-    const projectName = projectDirectory
-        .replace(/\//g, '-')
-        .replace(/\\/g, '-');
+    const projectName = projectDirectory.replace(`\\${path.sep}, g`, '-');
+
     const parsedTags = options.tags
         ? options.tags.split(',').map(s => s.trim())
         : [];

--- a/packages/common/core/src/lib/normalize-options.ts
+++ b/packages/common/core/src/lib/normalize-options.ts
@@ -39,7 +39,9 @@ export function normalizeOptions<TSchema extends BaseSchema>(
         projectDirectory,
     );
 
-    const projectName = projectDirectory.replace(`\\${path.sep}, g`, '-');
+    const projectName = projectDirectory
+        .replace(/\//g, '-')
+        .replace(/\\/g, '-');
 
     const parsedTags = options.tags
         ? options.tags.split(',').map(s => s.trim())

--- a/packages/common/core/src/lib/normalize-options.ts
+++ b/packages/common/core/src/lib/normalize-options.ts
@@ -39,7 +39,9 @@ export function normalizeOptions<TSchema extends BaseSchema>(
         projectDirectory,
     );
 
-    const projectName = projectDirectory.replace(/\//g, '-');
+    const projectName = projectDirectory
+        .replace(/\//g, '-')
+        .replace(/\\/g, '-');
     const parsedTags = options.tags
         ? options.tags.split(',').map(s => s.trim())
         : [];

--- a/packages/rest-client/src/generators/bump-version/generator.spec.ts
+++ b/packages/rest-client/src/generators/bump-version/generator.spec.ts
@@ -9,13 +9,18 @@ import { BumpVersionGeneratorSchema } from './schema';
 describe('bump-version generator', () => {
     let tree: Tree;
     const options: BumpVersionGeneratorSchema = {
-        directory: 'endpoints',
         name: 'test',
     };
 
     beforeEach(async () => {
         tree = createTreeWithEmptyWorkspace();
         tree.write('endpoints/test/v1/src/index.ts', 'test');
+        tree.write(
+            'endpoints/test/v1/project.json',
+            `{
+                "name": "test"
+            }`,
+        );
     });
 
     it('should throw a TypeError if version is not a number', async () => {
@@ -53,7 +58,6 @@ describe('bump-version generator', () => {
         tree.write('fixtures/endpoints/test/v1/src/index.ts', 'test');
         await generator(tree, {
             ...options,
-            directory: 'fixtures/endpoints',
         });
 
         expect(() =>
@@ -73,7 +77,6 @@ describe('bump-version generator', () => {
 
         await generator(tree, {
             ...options,
-            directory: 'fixtures/endpoints',
         });
 
         expect(() =>
@@ -85,7 +88,6 @@ describe('bump-version generator', () => {
         tree.write('fixtures/endpoints/test/v1/src/index.ts', 'test');
         await generator(tree, {
             ...options,
-            directory: 'fixtures/endpoints',
             endpointVersion: 3,
         });
 
@@ -104,32 +106,29 @@ describe('bump-version generator', () => {
         );
 
         tree.write(
-            'fixtures/endpoints/test/v1/src/index.ts',
+            'endpoints/test/v1/src/index.ts',
             fs.readFileSync(path.join(fixturesPath, 'index.ts.fixture')),
         );
         tree.write(
-            'fixtures/endpoints/test/v1/src/index.test.ts',
+            'endpoints/test/v1/src/index.test.ts',
             fs.readFileSync(path.join(fixturesPath, 'index.test.ts.fixture')),
         );
         tree.write(
-            'fixtures/endpoints/test/v1/src/index.types.ts',
+            'endpoints/test/v1/src/index.types.ts',
             fs.readFileSync(path.join(fixturesPath, 'index.types.ts.fixture')),
         );
 
         await generator(tree, {
             ...options,
-            directory: 'fixtures/endpoints',
             endpointVersion: 3,
         });
 
-        const indexTs = tree
-            .read('fixtures/endpoints/test/v3/src/index.ts')
-            ?.toString();
+        const indexTs = tree.read('endpoints/test/v3/src/index.ts')?.toString();
         const indexTestTs = tree
-            .read('fixtures/endpoints/test/v3/src/index.test.ts')
+            .read('endpoints/test/v3/src/index.test.ts')
             ?.toString();
         const indexTypesTs = tree
-            .read('fixtures/endpoints/test/v3/src/index.types.ts')
+            .read('endpoints/test/v3/src/index.types.ts')
             ?.toString();
 
         expect(indexTs).not.toContain(

--- a/packages/rest-client/src/generators/bump-version/generator.ts
+++ b/packages/rest-client/src/generators/bump-version/generator.ts
@@ -12,14 +12,21 @@ import { BumpVersionGeneratorSchema } from './schema';
 
 function findLatestVersion(
     tree: Tree,
-    { directory, endpointName }: { directory?: string; endpointName: string },
+    { endpointName }: { endpointName: string },
 ): number {
-    const versionsPath = readProjectConfiguration(
-        tree,
-        endpointName,
-    ).root.replace(/v(\d+)$/g, '');
+    let children;
+    try {
+        const versionsPath = readProjectConfiguration(
+            tree,
+            endpointName,
+        ).root.replace(/v(\d+)$/g, '');
 
-    const children = tree.children(versionsPath);
+        children = tree.children(versionsPath);
+    } catch {
+        throw new Error(
+            "Could not find previous version of the endpoint. Are you sure you don't want to generate a new endpoint?",
+        );
+    }
 
     if (children.length === 0) {
         throw new Error(
@@ -105,7 +112,6 @@ export default async function bumpVersion(
     optionsParameter: BumpVersionGeneratorSchema,
 ) {
     const latestVersion = findLatestVersion(tree, {
-        directory: optionsParameter.directory,
         endpointName: optionsParameter.name,
     });
 
@@ -129,7 +135,6 @@ export default async function bumpVersion(
 
     const latestVersionOptions = normalizeOptions(tree, {
         name: `${endpointRoot}v${latestVersion}`,
-        directory: optionsParameter.directory,
         endpointName: endpointRoot,
         endpointVersion: latestVersion,
     });

--- a/packages/rest-client/src/generators/bump-version/generator.ts
+++ b/packages/rest-client/src/generators/bump-version/generator.ts
@@ -104,6 +104,13 @@ export default async function bumpVersion(
         directory: optionsParameter.directory,
         endpointName: optionsParameter.name,
     });
+
+    if (Number.isNaN(latestVersion)) {
+        throw new TypeError(
+            `No version found. Please select your project with existing endpoints.`,
+        );
+    }
+
     const newVersion = determineNewVersion(
         latestVersion,
         optionsParameter.endpointVersion,

--- a/packages/rest-client/src/generators/bump-version/schema.d.ts
+++ b/packages/rest-client/src/generators/bump-version/schema.d.ts
@@ -1,5 +1,4 @@
 export interface BumpVersionGeneratorSchema {
     name: string;
-    directory: string;
     endpointVersion?: number;
 }

--- a/packages/rest-client/src/generators/bump-version/schema.json
+++ b/packages/rest-client/src/generators/bump-version/schema.json
@@ -16,11 +16,6 @@
             },
             "pattern": "^[a-z0-9_/-]+"
         },
-        "directory": {
-            "type": "string",
-            "description": "Subdirectory inside libs/ where the generated endpoint placed.",
-            "alias": "dir"
-        },
         "endpointVersion": {
             "type": "number",
             "description": "The version you want to bump your endpoint. Omitting this value will bump latest version + 1.",

--- a/packages/rest-client/src/generators/bump-version/schema.json
+++ b/packages/rest-client/src/generators/bump-version/schema.json
@@ -11,8 +11,7 @@
             "description": "The endpoint name you want to bump.",
             "x-prompt": "What is the name of the endpoint you want to bump?",
             "$default": {
-                "$source": "argv",
-                "index": 0
+                "$source": "projectName"
             },
             "pattern": "^[a-z0-9_/-]+"
         },

--- a/packages/rest-client/src/generators/client-endpoint/files/src/index.ts__template__
+++ b/packages/rest-client/src/generators/client-endpoint/files/src/index.ts__template__
@@ -1,6 +1,5 @@
-import httpClient, { RequestConfig, Response } from '<%= httpClient %>';
-
 import { <%= className %>, <%= className %>Data } from './index.types';
+import httpClient, { RequestConfig, Response } from '<%= httpClient %>';
 
 const API_ENDPOINT = `${process.env.<%= envVar %>}/<%= endpointName %>/v<%= endpointVersion %>`;
 


### PR DESCRIPTION
[5524](https://dev.azure.com/amido-dev/Amido-Stacks/_workitems/edit/5524)

- replaces both slashes when normalizing options
- import linting fix
- typeError for unacceptable project to bump version
- removes directory option for bump-version generator as it reads project list