### PR TITLE
feat(next): use application name as redis name instead of resource group

### DIFF
--- a/packages/next/src/generators/next-auth-redis-deployment/files/azure/deploy/terraform/variables/nonprod/redis.tfvars
+++ b/packages/next/src/generators/next-auth-redis-deployment/files/azure/deploy/terraform/variables/nonprod/redis.tfvars
@@ -1,3 +1,3 @@
-redis_name                    = "<%= nonProdResourceGroup %>"
+redis_name                    = "<%= projectName %>"
 redis_resource_group_location = "%REPLACE%"
 redis_resource_group_name     = "<%= nonProdResourceGroup %>"

--- a/packages/next/src/generators/next-auth-redis-deployment/files/azure/deploy/terraform/variables/prod/redis.tfvars
+++ b/packages/next/src/generators/next-auth-redis-deployment/files/azure/deploy/terraform/variables/prod/redis.tfvars
@@ -1,3 +1,3 @@
-redis_name                    = "<%= prodResourceGroup %>"
+redis_name                    = "<%= projectName %>"
 redis_resource_group_location = "%REPLACE%"
 redis_resource_group_name     = "<%= prodResourceGroup %>"

--- a/packages/next/src/generators/next-auth-redis-deployment/generator.ts
+++ b/packages/next/src/generators/next-auth-redis-deployment/generator.ts
@@ -39,6 +39,7 @@ export default async function nextAuthRedisDeploymentGenerator(
         path.join(__dirname, `files/${stacksConfig.cloud.platform}`),
         project.root,
         {
+            projectName: project.name,
             nonProdResourceGroup: getResourceGroup(stacksConfig, 'nonprod'),
             prodResourceGroup: getResourceGroup(stacksConfig, 'prod'),
         },


### PR DESCRIPTION
Ticket [5761](https://dev.azure.com/amido-dev/Amido-Stacks/_workitems/edit/5761)

- Change redis_name in terraform to use application name by default