### PR TITLE
fix(rest-client): support windows bumping version for endpoints

### DIFF
--- a/packages/rest-client/src/generators/bump-version/generator.ts
+++ b/packages/rest-client/src/generators/bump-version/generator.ts
@@ -126,12 +126,11 @@ export default async function bumpVersion(
         optionsParameter.endpointVersion,
     );
 
-    const libsEndpoint = readProjectConfiguration(
-        tree,
-        optionsParameter.name,
-    ).root.replace(/v(\d+)$/g, '');
+    const libsEndpoint = readProjectConfiguration(tree, optionsParameter.name)
+        .root.replace(/v(\d+)$/g, '')
+        .replace(/\v(\d+)$/g, '');
 
-    const endpointRoot = libsEndpoint.replace('libs/', '');
+    const endpointRoot = libsEndpoint.replace('libs/', '').replace('libs', '');
 
     const latestVersionOptions = normalizeOptions(tree, {
         name: `${endpointRoot}v${latestVersion}`,


### PR DESCRIPTION
[5538](https://dev.azure.com/amido-dev/Amido-Stacks/_workitems/edit/5538)

- replace util to cover windows forward slash