### PR TITLE
fix(azure-node): update pipeline stages yaml for app insights

### DIFF
--- a/packages/azure-node/src/generators/app-insights-deployment/generator.ts
+++ b/packages/azure-node/src/generators/app-insights-deployment/generator.ts
@@ -1,6 +1,7 @@
 import { readProjectConfiguration, Tree } from '@nrwl/devkit';
 
 import { AppInsightsDeploymentGeneratorSchema } from './schema';
+import { updatePipelineStagesYaml } from './utils/update-pipeline';
 import { updateProjectJsonHelmUpgradeTarget } from './utils/update-targets';
 
 export default async function appInsightsDeploymentGenerator(
@@ -11,4 +12,5 @@ export default async function appInsightsDeploymentGenerator(
 
     // Update project.json
     updateProjectJsonHelmUpgradeTarget(project, tree, options);
+    updatePipelineStagesYaml(tree, options);
 }

--- a/packages/azure-node/src/generators/app-insights-deployment/utils/update-pipeline.ts
+++ b/packages/azure-node/src/generators/app-insights-deployment/utils/update-pipeline.ts
@@ -1,0 +1,45 @@
+import { Tree } from '@nrwl/devkit';
+import YAML from 'yaml';
+
+import { AppInsightsDeploymentGeneratorSchema } from '../schema';
+
+export function updatePipelineStagesYaml(
+    tree: Tree,
+    options: AppInsightsDeploymentGeneratorSchema,
+) {
+    // Update values yaml
+    const filePath = 'build/azDevOps/azuredevops-stages.yaml';
+
+    // Skip if file doesn't exist
+    if (!tree.exists(filePath)) return;
+
+    const stagesYAML = YAML.parse(tree.read(filePath, 'utf-8'));
+
+    // Find deployment step
+    const stageIndex = stagesYAML.stages.findIndex(
+        item => item.stage === `Build_\${{ parameters.environment }}`,
+    );
+    const jobIndex = stagesYAML.stages[stageIndex].jobs.findIndex(
+        item => item.job === 'Build',
+    );
+    const stepIndex = stagesYAML.stages[stageIndex].jobs[
+        jobIndex
+    ].steps.findIndex(
+        item =>
+            item.displayName ===
+            `build_deployment_\${{ parameters.environment }}`,
+    );
+    const deploymentStep =
+        stagesYAML.stages[stageIndex].jobs[jobIndex].steps[stepIndex];
+
+    // Create empty env if it doesn't already exist
+    if (!deploymentStep.env) {
+        deploymentStep.env = {};
+    }
+
+    deploymentStep.env[
+        options.applicationinsightsConnectionString
+    ] = `$(${options.applicationinsightsConnectionString})`;
+
+    tree.write(filePath, YAML.stringify(stagesYAML));
+}


### PR DESCRIPTION
If the app insights connection string is set in an ADO variable group as a secret then it will not set correctly during the deployment. The workaround is to set it as an environment variable on the deployment step.

- Find correct deployment step
- Update environment variables in stages yaml