### PR TITLE
fix(next): remove with-nx copy from dockerfile

### DIFF
--- a/packages/next/src/generators/init-deployment/files/apps/common/Dockerfile
+++ b/packages/next/src/generators/init-deployment/files/apps/common/Dockerfile
@@ -17,7 +17,6 @@ WORKDIR /usr/src/app
 COPY --from=deps /usr/src/app/node_modules ./node_modules
 COPY --from=deps /usr/src/app/package.json ./package.json
 COPY <%= distFolderPath %>/next.config.js ./next.config.js
-COPY <%= distFolderPath %>/with-nx.js ./with-nx.js
 COPY <%= distFolderPath %>/public ./public
 <% if(customServerRelativePath) { %>
 COPY <%= distFolderPath %>/server ./server


### PR DESCRIPTION
Ticket: [5792](https://dev.azure.com/amido-dev/Amido-Stacks/_workitems/edit/5792)

- Remove with-nx.json copy from the dockerfile
- Requires the latest version of nx and nrwl/next to work