### PR TITLE
fix(next): update init-deployment with allowEmptyRelease

### DIFF
--- a/packages/next/src/generators/init-deployment/utils/common.ts
+++ b/packages/next/src/generators/init-deployment/utils/common.ts
@@ -170,6 +170,7 @@ export function addCommon(tree: Tree, options: NextGeneratorSchema) {
         executor: '@jscutlery/semver:version',
         options: {
             preset: 'conventional',
+            allowEmptyRelease: true,
             trackDeps: true,
             skipCommit: true,
             dryRun: true,


### PR DESCRIPTION
Updated init-deployment to allowEmptyRelease when running the semver:version executor. 

In cases where Nx wants to rebuild/deploy applications (i.e due to a workspace change such as dependency updates) semver will not version the application if it would be an empty release. However, we need to enable this so that applications can deploy to a new version when workspace changes affect it