### PR TITLE
fix(next): Fixes for open telemetry

### DIFF
--- a/packages/next/src/generators/init-deployment/files/apps/common/deploy/helm/nonprod/values.yaml
+++ b/packages/next/src/generators/init-deployment/files/apps/common/deploy/helm/nonprod/values.yaml
@@ -15,3 +15,6 @@ ingress:
     tls:
         - hosts:
               - <%= internalDomain %>
+
+podAnnotations:
+    instrumentation.opentelemetry.io/inject-nodejs: '<%= openTelemetry %>'

--- a/packages/next/src/generators/init-deployment/files/apps/common/deploy/helm/prod/values.yaml
+++ b/packages/next/src/generators/init-deployment/files/apps/common/deploy/helm/prod/values.yaml
@@ -15,3 +15,6 @@ ingress:
     tls:
         - hosts:
               - <%= externalDomain %>
+
+podAnnotations:
+    instrumentation.opentelemetry.io/inject-nodejs: '<%= openTelemetry %>'

--- a/packages/next/src/generators/init-deployment/files/libs/common/build/helm/values.yaml
+++ b/packages/next/src/generators/init-deployment/files/libs/common/build/helm/values.yaml
@@ -30,9 +30,6 @@ serviceAccount:
     # If not set and create is true, a name is generated using the fullname template
     name: ''
 
-podAnnotations:
-    instrumentation.opentelemetry.io/inject-nodejs: '<%= openTelemetry %>'
-
 # fsGroup: 2000
 podSecurityContext:
     {}

--- a/packages/next/src/generators/init-deployment/generator.spec.ts
+++ b/packages/next/src/generators/init-deployment/generator.spec.ts
@@ -159,23 +159,47 @@ describe('next deployment generator', () => {
                 await createNextApp();
                 tree.write('.prettierignore', '');
                 await generator(tree, { ...options, openTelemetry: true });
-
-                expect(
-                    tree.exists('libs/next-helm-chart/build/helm/values.yaml'),
-                ).toBeTruthy();
-                expect(
-                    tree.exists('next-app/deploy/helm/nonprod/values.yaml'),
-                ).toBeTruthy();
-                expect(
-                    tree.exists('next-app/deploy/helm/prod/values.yaml'),
-                ).toBeTruthy();
-
-                const defaultHelmValues = tree.read(
-                    'libs/next-helm-chart/build/helm/values.yaml',
-                    'utf-8',
-                );
-                expect(defaultHelmValues).toContain(
+                const defaultValuesPath =
+                    'libs/next-helm-chart/build/helm/values.yaml';
+                const nonProdValuesPath =
+                    'next-app/deploy/helm/nonprod/values.yaml';
+                const prodValuesPath = 'next-app/deploy/helm/prod/values.yaml';
+                expect(tree.exists(defaultValuesPath)).toBeTruthy();
+                expect(tree.exists(nonProdValuesPath)).toBeTruthy();
+                expect(tree.exists(prodValuesPath)).toBeTruthy();
+                expect(tree.read(defaultValuesPath, 'utf-8')).not.toContain(
                     "instrumentation.opentelemetry.io/inject-nodejs: 'true'",
+                );
+                expect(tree.read(nonProdValuesPath, 'utf-8')).toContain(
+                    "instrumentation.opentelemetry.io/inject-nodejs: 'true'",
+                );
+                expect(tree.read(prodValuesPath, 'utf-8')).toContain(
+                    "instrumentation.opentelemetry.io/inject-nodejs: 'true'",
+                );
+            });
+        });
+
+        describe('--openTelemetry omitted', () => {
+            it('should not add auto-instrumentation for OpenTelemetry if false', async () => {
+                await createNextApp();
+                tree.write('.prettierignore', '');
+                await generator(tree, { ...options, openTelemetry: false });
+                const defaultValuesPath =
+                    'libs/next-helm-chart/build/helm/values.yaml';
+                const nonProdValuesPath =
+                    'next-app/deploy/helm/nonprod/values.yaml';
+                const prodValuesPath = 'next-app/deploy/helm/prod/values.yaml';
+                expect(tree.exists(defaultValuesPath)).toBeTruthy();
+                expect(tree.exists(nonProdValuesPath)).toBeTruthy();
+                expect(tree.exists(prodValuesPath)).toBeTruthy();
+                expect(tree.read(defaultValuesPath, 'utf-8')).not.toContain(
+                    "instrumentation.opentelemetry.io/inject-nodejs: 'false'",
+                );
+                expect(tree.read(nonProdValuesPath, 'utf-8')).toContain(
+                    "instrumentation.opentelemetry.io/inject-nodejs: 'false'",
+                );
+                expect(tree.read(prodValuesPath, 'utf-8')).toContain(
+                    "instrumentation.opentelemetry.io/inject-nodejs: 'false'",
                 );
             });
         });

--- a/packages/next/src/generators/init-deployment/utils/add-infrastructure.ts
+++ b/packages/next/src/generators/init-deployment/utils/add-infrastructure.ts
@@ -49,7 +49,7 @@ export function addInfrastructure(
 
     tasks.push(() => {
         logger.warn(
-            `Review the infrastructure files in ${project.root}/build/. Search for "%REPLACE% and make any necessary changes.`,
+            `Review the infrastructure files in ${project.root}/build/. Search for "%REPLACE%" and make any necessary changes.`,
         );
     });
 

--- a/packages/next/src/generators/init-deployment/utils/common.ts
+++ b/packages/next/src/generators/init-deployment/utils/common.ts
@@ -92,6 +92,7 @@ export function addCommon(tree: Tree, options: NextGeneratorSchema) {
             projectName: project.name,
             internalDomain: stacksConfig.domain.internal,
             externalDomain: stacksConfig.domain.external,
+            openTelemetry: options.openTelemetry,
         },
     );
 
@@ -111,7 +112,6 @@ export function addCommon(tree: Tree, options: NextGeneratorSchema) {
                 namespace,
                 internalDomain: stacksConfig.domain.internal,
                 externalDomain: stacksConfig.domain.external,
-                openTelemetry: options.openTelemetry,
             },
         );
     }


### PR DESCRIPTION
What?

Remove auto instrumentation from workspace level values.yaml and add this into the individual values.yaml files for prod/nonprod within the application deploy folders.

Why?

To enable us to set auto instrumentation for openTelemetry on a per application basis