### PR TITLE
fix(common-core): Deployment generators run without relevant files in place

### DIFF
--- a/packages/azure-node/src/generators/app-insights-deployment/generator.spec.ts
+++ b/packages/azure-node/src/generators/app-insights-deployment/generator.spec.ts
@@ -1,7 +1,4 @@
-import {
-    addStacksAttributes,
-    resetStacksExecutedGeneratorsAttributes,
-} from '@ensono-stacks/test';
+import { addStacksAttributes, executeWorkspaceInit } from '@ensono-stacks/test';
 import { readJson, Tree, updateJson } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { applicationGenerator } from '@nrwl/next';
@@ -45,6 +42,7 @@ describe('app-insights-deployment generator', () => {
     });
 
     it('should update project.json with environment variable', async () => {
+        await executeWorkspaceInit(appTree);
         await generator(appTree, options);
 
         const projectFile = appTree.read('next-app/project.json');
@@ -54,10 +52,6 @@ describe('app-insights-deployment generator', () => {
     });
 
     describe('executedDependantGenerator', () => {
-        beforeEach(async () => {
-            resetStacksExecutedGeneratorsAttributes(appTree);
-        });
-
         it('returns false if no prerequisite present', async () => {
             const gen = await generator(appTree, {
                 ...options,
@@ -69,6 +63,7 @@ describe('app-insights-deployment generator', () => {
 
     describe('executedGenerators', () => {
         beforeEach(async () => {
+            await executeWorkspaceInit(appTree);
             await generator(appTree, options);
         });
 

--- a/packages/azure-node/src/generators/app-insights-deployment/generator.spec.ts
+++ b/packages/azure-node/src/generators/app-insights-deployment/generator.spec.ts
@@ -1,4 +1,7 @@
-import { addStacksAttributes } from '@ensono-stacks/test';
+import {
+    addStacksAttributes,
+    resetStacksExecutedGeneratorsAttributes,
+} from '@ensono-stacks/test';
 import { readJson, Tree, updateJson } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { applicationGenerator } from '@nrwl/next';
@@ -48,6 +51,20 @@ describe('app-insights-deployment generator', () => {
         expect(projectFile.toString()).toContain(
             'env.APPLICATIONINSIGHTS_CONNECTIONS_STRING=$APPLICATIONINSIGHTS_CONNECTIONS_STRING',
         );
+    });
+
+    describe('executedDependantGenerator', () => {
+        beforeEach(async () => {
+            resetStacksExecutedGeneratorsAttributes(appTree);
+        });
+
+        it('returns false if no prerequisite present', async () => {
+            const gen = await generator(appTree, {
+                ...options,
+            });
+
+            expect(gen).toBe(false);
+        });
     });
 
     describe('executedGenerators', () => {

--- a/packages/azure-node/src/generators/app-insights-deployment/generator.ts
+++ b/packages/azure-node/src/generators/app-insights-deployment/generator.ts
@@ -1,6 +1,6 @@
 import {
+    executedDependantGenerator,
     hasGeneratorExecutedForProject,
-    hasGeneratorExecutedForWorkspace,
 } from '@ensono-stacks/core';
 import { readProjectConfiguration, Tree } from '@nrwl/devkit';
 
@@ -14,6 +14,7 @@ export default async function appInsightsDeploymentGenerator(
     tree: Tree,
     options: AppInsightsDeploymentGeneratorSchema,
 ) {
+    if (!executedDependantGenerator(tree, 'WorkspaceInit')) return false;
     if (
         hasGeneratorExecutedForProject(
             tree,

--- a/packages/azure-node/src/generators/app-insights-deployment/generator.ts
+++ b/packages/azure-node/src/generators/app-insights-deployment/generator.ts
@@ -14,7 +14,8 @@ export default async function appInsightsDeploymentGenerator(
     tree: Tree,
     options: AppInsightsDeploymentGeneratorSchema,
 ) {
-    if (!executedDependantGenerator(tree, 'WorkspaceInit')) return false;
+    if (!executedDependantGenerator(tree, 'WorkspaceInit', options.project))
+        return false;
     if (
         hasGeneratorExecutedForProject(
             tree,

--- a/packages/common/core/src/utils/executedDependantGenerator.spec.ts
+++ b/packages/common/core/src/utils/executedDependantGenerator.spec.ts
@@ -30,7 +30,7 @@ describe('executedDependantGenerator', () => {
         expect(result).toBe(false);
     });
 
-    it('should return true if prerequisite present', async () => {
+    it('should return true if prerequisite present in workspace', async () => {
         updateJson(appTree, 'nx.json', nxJson => ({
             ...nxJson,
             stacks: {
@@ -45,5 +45,53 @@ describe('executedDependantGenerator', () => {
         const result = executedDependantGenerator(appTree, generatorName);
 
         expect(result).toBe(true);
+    });
+
+    it('should return true if prerequisite present in project', async () => {
+        updateJson(appTree, 'nx.json', nxJson => ({
+            ...nxJson,
+            stacks: {
+                ...nxJson.stacks,
+                executedGenerators: {
+                    ...nxJson.stacks.executedGenerators,
+                    workspace: [],
+                    project: {
+                        test: [generatorName],
+                    },
+                },
+            },
+        }));
+
+        const result = executedDependantGenerator(
+            appTree,
+            generatorName,
+            'test',
+        );
+
+        expect(result).toBe(true);
+    });
+
+    it('should return false if no prerequisite present for workspace and project', async () => {
+        updateJson(appTree, 'nx.json', nxJson => ({
+            ...nxJson,
+            stacks: {
+                ...nxJson.stacks,
+                executedGenerators: {
+                    ...nxJson.stacks.executedGenerators,
+                    workspace: [],
+                    project: {
+                        test: [],
+                    },
+                },
+            },
+        }));
+
+        const result = executedDependantGenerator(
+            appTree,
+            generatorName,
+            'test',
+        );
+
+        expect(result).toBe(false);
     });
 });

--- a/packages/common/core/src/utils/executedDependantGenerator.spec.ts
+++ b/packages/common/core/src/utils/executedDependantGenerator.spec.ts
@@ -1,0 +1,49 @@
+import { addStacksAttributes } from '@ensono-stacks/test';
+import { Tree, updateJson } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import chalk from 'chalk';
+
+import { executedDependantGenerator } from './executedDependantGenerator';
+
+describe('executedDependantGenerator', () => {
+    let appTree: Tree;
+    const generatorName = 'testGenerator';
+
+    beforeEach(async () => {
+        appTree = createTreeWithEmptyWorkspace();
+        addStacksAttributes(appTree, '');
+    });
+
+    it('should return false if no prerequisite present', async () => {
+        const logSpy = jest.spyOn(global.console, 'log');
+
+        const result = executedDependantGenerator(appTree, generatorName);
+
+        expect(logSpy).toBeCalledWith(
+            '\n',
+            chalk.yellow`The following generator is required as a prerequisite for this generator to work:`,
+            chalk.magenta`testGenerator.`,
+            chalk.yellow`No changes made.`,
+            '\n',
+        );
+
+        expect(result).toBe(false);
+    });
+
+    it('should return true if prerequisite present', async () => {
+        updateJson(appTree, 'nx.json', nxJson => ({
+            ...nxJson,
+            stacks: {
+                ...nxJson.stacks,
+                executedGenerators: {
+                    ...nxJson.stacks.executedGenerators,
+                    workspace: [generatorName],
+                },
+            },
+        }));
+
+        const result = executedDependantGenerator(appTree, generatorName);
+
+        expect(result).toBe(true);
+    });
+});

--- a/packages/common/core/src/utils/executedDependantGenerator.ts
+++ b/packages/common/core/src/utils/executedDependantGenerator.ts
@@ -15,7 +15,7 @@ export function executedDependantGenerator(
 
     if (projectName) {
         projectGenerator =
-            readStacksExecutedGenerators(tree).project[projectName].includes(
+            readStacksExecutedGenerators(tree).project[projectName]?.includes(
                 generatorName,
             );
     }

--- a/packages/common/core/src/utils/executedDependantGenerator.ts
+++ b/packages/common/core/src/utils/executedDependantGenerator.ts
@@ -1,0 +1,21 @@
+import { Tree } from '@nrwl/devkit';
+import chalk from 'chalk';
+
+import { readStacksExecutedGenerators } from '../lib/stacks';
+
+export function executedDependantGenerator(tree: Tree, generatorName: string) {
+    const generatorExecuted =
+        readStacksExecutedGenerators(tree).workspace.includes(generatorName);
+
+    if (!generatorExecuted) {
+        console.log(
+            '\n',
+            chalk.yellow`The following generator is required as a prerequisite for this generator to work:`,
+            chalk.magenta`${generatorName}.`,
+            chalk.yellow`No changes made.`,
+            '\n',
+        );
+    }
+
+    return generatorExecuted;
+}

--- a/packages/common/core/src/utils/executedDependantGenerator.ts
+++ b/packages/common/core/src/utils/executedDependantGenerator.ts
@@ -3,9 +3,24 @@ import chalk from 'chalk';
 
 import { readStacksExecutedGenerators } from '../lib/stacks';
 
-export function executedDependantGenerator(tree: Tree, generatorName: string) {
-    const generatorExecuted =
+export function executedDependantGenerator(
+    tree: Tree,
+    generatorName: string,
+    projectName?: string,
+) {
+    let projectGenerator = false;
+
+    const workspaceGenerator =
         readStacksExecutedGenerators(tree).workspace.includes(generatorName);
+
+    if (projectName) {
+        projectGenerator =
+            readStacksExecutedGenerators(tree).project[projectName].includes(
+                generatorName,
+            );
+    }
+
+    const generatorExecuted = workspaceGenerator || projectGenerator;
 
     if (!generatorExecuted) {
         console.log(

--- a/packages/common/core/src/utils/index.ts
+++ b/packages/common/core/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './addCustomTestConfig';
+export * from './executedDependantGenerator';
 export * from './deploymentGeneratorMessage';
 export * from './formatFiles';
 export * from './hasGeneratorExecuted';

--- a/packages/common/test/src/lib/stacks-attributes.ts
+++ b/packages/common/test/src/lib/stacks-attributes.ts
@@ -30,7 +30,7 @@ export function addStacksAttributes(tree: Tree, project: string) {
         project: {
             [project]: [],
         },
-        workspace: ['WorkspaceInit'],
+        workspace: [],
     };
 
     updateJson(tree, 'nx.json', nxJson => ({
@@ -44,14 +44,14 @@ export function addStacksAttributes(tree: Tree, project: string) {
     return { stacksConfig, stacksExecutedGenerators };
 }
 
-export function resetStacksExecutedGeneratorsAttributes(tree: Tree) {
+export function executeWorkspaceInit(tree: Tree) {
     updateJson(tree, 'nx.json', nxJson => ({
         ...nxJson,
         stacks: {
             ...nxJson.stacks,
             executedGenerators: {
-                project: {},
-                workspace: [],
+                ...nxJson.stacks.executedGenerators,
+                workspace: ['WorkspaceInit'],
             },
         },
     }));

--- a/packages/common/test/src/lib/stacks-attributes.ts
+++ b/packages/common/test/src/lib/stacks-attributes.ts
@@ -30,7 +30,7 @@ export function addStacksAttributes(tree: Tree, project: string) {
         project: {
             [project]: [],
         },
-        workspace: [],
+        workspace: ['WorkspaceInit'],
     };
 
     updateJson(tree, 'nx.json', nxJson => ({
@@ -42,4 +42,17 @@ export function addStacksAttributes(tree: Tree, project: string) {
     }));
 
     return { stacksConfig, stacksExecutedGenerators };
+}
+
+export function resetStacksExecutedGeneratorsAttributes(tree: Tree) {
+    updateJson(tree, 'nx.json', nxJson => ({
+        ...nxJson,
+        stacks: {
+            ...nxJson.stacks,
+            executedGenerators: {
+                project: {},
+                workspace: [],
+            },
+        },
+    }));
 }

--- a/packages/next/src/generators/init-deployment/generator.spec.ts
+++ b/packages/next/src/generators/init-deployment/generator.spec.ts
@@ -1,7 +1,4 @@
-import {
-    addStacksAttributes,
-    resetStacksExecutedGeneratorsAttributes,
-} from '@ensono-stacks/test';
+import { addStacksAttributes, executeWorkspaceInit } from '@ensono-stacks/test';
 import { readJson, Tree } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { applicationGenerator } from '@nrwl/next';
@@ -33,6 +30,7 @@ describe('next deployment generator', () => {
     describe('infrastructure', () => {
         it('should throw if project is not defined', async () => {
             await createNextApp({});
+            await executeWorkspaceInit(tree);
             await expect(
                 generator(tree, {
                     ...options,
@@ -73,6 +71,7 @@ describe('next deployment generator', () => {
         it('should scaffold with infrastructure', async () => {
             await createNextApp();
             tree.write('.prettierignore', '');
+            await executeWorkspaceInit(tree);
             await generator(tree, { ...options });
 
             expect(tree.exists('next-app/Dockerfile')).toBeTruthy();
@@ -106,6 +105,7 @@ describe('next deployment generator', () => {
 
         it('should scaffold with infrastructure on a custom server', async () => {
             await createNextApp({ customServer: true });
+            await executeWorkspaceInit(tree);
             await generator(tree, { ...options });
 
             expect(tree.exists('next-app/Dockerfile')).toBeTruthy();
@@ -133,10 +133,6 @@ describe('next deployment generator', () => {
         });
 
         describe('executedDependantGenerator', () => {
-            beforeEach(async () => {
-                resetStacksExecutedGeneratorsAttributes(tree);
-            });
-
             it('returns false if no prerequisite present', async () => {
                 const gen = await generator(tree, {
                     ...options,
@@ -149,6 +145,7 @@ describe('next deployment generator', () => {
         describe('executedGenerators', () => {
             beforeEach(async () => {
                 await createNextApp({});
+                await executeWorkspaceInit(tree);
                 await generator(tree, options);
             });
 
@@ -175,6 +172,7 @@ describe('next deployment generator', () => {
             it('should add auto-instrumentation for OpenTelemetry if true', async () => {
                 await createNextApp();
                 tree.write('.prettierignore', '');
+                await executeWorkspaceInit(tree);
                 await generator(tree, { ...options, openTelemetry: true });
                 const defaultValuesPath =
                     'libs/next-helm-chart/build/helm/values.yaml';
@@ -200,6 +198,7 @@ describe('next deployment generator', () => {
             it('should not add auto-instrumentation for OpenTelemetry if false', async () => {
                 await createNextApp();
                 tree.write('.prettierignore', '');
+                await executeWorkspaceInit(tree);
                 await generator(tree, { ...options, openTelemetry: false });
                 const defaultValuesPath =
                     'libs/next-helm-chart/build/helm/values.yaml';

--- a/packages/next/src/generators/init-deployment/generator.spec.ts
+++ b/packages/next/src/generators/init-deployment/generator.spec.ts
@@ -1,4 +1,7 @@
-import { addStacksAttributes } from '@ensono-stacks/test';
+import {
+    addStacksAttributes,
+    resetStacksExecutedGeneratorsAttributes,
+} from '@ensono-stacks/test';
 import { readJson, Tree } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import { applicationGenerator } from '@nrwl/next';
@@ -127,6 +130,20 @@ describe('next deployment generator', () => {
             expect(docker).toContain(
                 'CMD ["dumb-init", "node", "server/main.js"]',
             );
+        });
+
+        describe('executedDependantGenerator', () => {
+            beforeEach(async () => {
+                resetStacksExecutedGeneratorsAttributes(tree);
+            });
+
+            it('returns false if no prerequisite present', async () => {
+                const gen = await generator(tree, {
+                    ...options,
+                });
+
+                expect(gen).toBe(false);
+            });
         });
 
         describe('executedGenerators', () => {

--- a/packages/next/src/generators/init-deployment/generator.spec.ts
+++ b/packages/next/src/generators/init-deployment/generator.spec.ts
@@ -36,7 +36,9 @@ describe('next deployment generator', () => {
                     ...options,
                     project: 'unknown',
                 }),
-            ).rejects.toThrowError("Cannot find configuration for 'unknown'");
+            ).rejects.toThrowError(
+                "Cannot read properties of undefined (reading 'includes')",
+            );
         });
 
         it('should not apply if stacks config is missing', async () => {

--- a/packages/next/src/generators/init-deployment/generator.spec.ts
+++ b/packages/next/src/generators/init-deployment/generator.spec.ts
@@ -36,9 +36,7 @@ describe('next deployment generator', () => {
                     ...options,
                     project: 'unknown',
                 }),
-            ).rejects.toThrowError(
-                "Cannot read properties of undefined (reading 'includes')",
-            );
+            ).rejects.toThrowError("Cannot find configuration for 'unknown'");
         });
 
         it('should not apply if stacks config is missing', async () => {

--- a/packages/next/src/generators/init-deployment/generator.ts
+++ b/packages/next/src/generators/init-deployment/generator.ts
@@ -20,7 +20,8 @@ export default async function initDeploymentGenerator(
     tree: Tree,
     options: NextGeneratorSchema,
 ) {
-    if (!executedDependantGenerator(tree, 'WorkspaceInit')) return false;
+    if (!executedDependantGenerator(tree, 'WorkspaceInit', options.project))
+        return false;
     if (
         hasGeneratorExecutedForProject(
             tree,

--- a/packages/next/src/generators/init-deployment/generator.ts
+++ b/packages/next/src/generators/init-deployment/generator.ts
@@ -1,5 +1,6 @@
 import {
     formatFiles,
+    executedDependantGenerator,
     hasGeneratorExecutedForProject,
     StacksError,
 } from '@ensono-stacks/core';
@@ -19,6 +20,7 @@ export default async function initDeploymentGenerator(
     tree: Tree,
     options: NextGeneratorSchema,
 ) {
+    if (!executedDependantGenerator(tree, 'WorkspaceInit')) return false;
     if (
         hasGeneratorExecutedForProject(
             tree,

--- a/packages/playwright/src/generators/init-deployment/generator.spec.ts
+++ b/packages/playwright/src/generators/init-deployment/generator.spec.ts
@@ -1,7 +1,4 @@
-import {
-    addStacksAttributes,
-    resetStacksExecutedGeneratorsAttributes,
-} from '@ensono-stacks/test';
+import { addStacksAttributes, executeWorkspaceInit } from '@ensono-stacks/test';
 import { readJson, Tree } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import YAML from 'yaml';
@@ -65,6 +62,7 @@ describe('playwright generator', () => {
     });
 
     it('should run successfully with default options', async () => {
+        await executeWorkspaceInit(appTree);
         await generator(appTree);
 
         const taskctlYAML = YAML.parse(appTree.read('taskctl.yaml', 'utf8'));
@@ -156,6 +154,7 @@ stages:
 
 `,
         );
+        await executeWorkspaceInit(appTree);
         await generator(appTree);
 
         const stages = YAML.parse(
@@ -203,10 +202,6 @@ stages:
     });
 
     describe('executedDependantGenerator', () => {
-        beforeEach(async () => {
-            resetStacksExecutedGeneratorsAttributes(appTree);
-        });
-
         it('returns false if no prerequisite present', async () => {
             const gen = await generator(appTree);
 
@@ -216,6 +211,7 @@ stages:
 
     describe('executedGenerators', () => {
         beforeEach(async () => {
+            await executeWorkspaceInit(appTree);
             await generator(appTree);
         });
 

--- a/packages/playwright/src/generators/init-deployment/generator.spec.ts
+++ b/packages/playwright/src/generators/init-deployment/generator.spec.ts
@@ -1,4 +1,7 @@
-import { addStacksAttributes } from '@ensono-stacks/test';
+import {
+    addStacksAttributes,
+    resetStacksExecutedGeneratorsAttributes,
+} from '@ensono-stacks/test';
 import { readJson, Tree } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
 import YAML from 'yaml';
@@ -196,6 +199,18 @@ stages:
                 artifact: 'testresults',
                 publishLocation: 'pipeline',
             },
+        });
+    });
+
+    describe('executedDependantGenerator', () => {
+        beforeEach(async () => {
+            resetStacksExecutedGeneratorsAttributes(appTree);
+        });
+
+        it('returns false if no prerequisite present', async () => {
+            const gen = await generator(appTree);
+
+            expect(gen).toBe(false);
         });
     });
 

--- a/packages/playwright/src/generators/init-deployment/generator.ts
+++ b/packages/playwright/src/generators/init-deployment/generator.ts
@@ -1,4 +1,7 @@
-import { hasGeneratorExecutedForWorkspace } from '@ensono-stacks/core';
+import {
+    executedDependantGenerator,
+    hasGeneratorExecutedForWorkspace,
+} from '@ensono-stacks/core';
 import { formatFiles, Tree } from '@nrwl/devkit';
 
 import { updateAzureDevopsStages } from './utils/update-azdevops-build';
@@ -6,6 +9,7 @@ import { updateTaskctlYaml, updateTasksYaml } from './utils/update-tasks-yamls';
 
 // eslint-disable-next-line consistent-return
 export default async function initDeploymentGenerator(tree: Tree) {
+    if (!executedDependantGenerator(tree, 'WorkspaceInit')) return false;
     if (hasGeneratorExecutedForWorkspace(tree, 'PlaywrightInitDeployment'))
         return false;
 

--- a/packages/workspace/src/generators/init/generator.spec.ts
+++ b/packages/workspace/src/generators/init/generator.spec.ts
@@ -187,6 +187,8 @@ describe('init generator', () => {
         });
 
         it('should configure prepare-commit-msg and commit-msg for commitlint', async () => {
+            await addStacksAttributes(tree, '');
+
             await generator(tree, {
                 ...options,
                 eslint: false,


### PR DESCRIPTION
#### 📲 What

Created new util in common core to check for existing workspace generator name

#### 🤔 Why

For deployment generators, workspace init is a prerequisite. This enables control.

#### 🛠 How

Each deployment generator calls this new util method first before continuing.

#### 👀 Evidence

Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR

#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
