### PR TITLE
fix(rest-client) Use path relation rather than startsWith

### DIFF
--- a/packages/rest-client/src/generators/bump-version/generator.ts
+++ b/packages/rest-client/src/generators/bump-version/generator.ts
@@ -107,6 +107,11 @@ function updateVersionInCode(
     });
 }
 
+function isRelative(parent: string, directory: string) {
+    const relative = path.relative(parent, directory);
+    return relative && !relative.startsWith('..') && !path.isAbsolute(relative);
+}
+
 export default async function bumpVersion(
     tree: Tree,
     optionsParameter: BumpVersionGeneratorSchema,
@@ -146,7 +151,6 @@ export default async function bumpVersion(
         endpointName: endpointRoot,
         endpointVersion: newVersion,
     });
-
     // create a new library for the new version
     await libraryGenerator(tree, newVersionOptions);
     // Delete the default generated lib folder
@@ -162,7 +166,9 @@ export default async function bumpVersion(
     // update version numbers in the newly created files
     const filesToChange = tree
         .listChanges()
-        .filter(change => change.path.startsWith(newVersionOptions.projectRoot))
+        .filter(change =>
+            isRelative(newVersionOptions.projectRoot, change.path),
+        )
         .map(change => change.path);
     updateVersionInCode(
         tree,


### PR DESCRIPTION
#### 📲 What

Change bumpVersion function in rest client to check for path relativity

#### 🤔 Why

Because paths are treated differently between operating systems, therefore checking path relativity using the startsWith method will not guarantee results across OS

#### 🛠 How

New isRelative function, using the path.relative function to determine if a path is a child directory of a parent

#### 👀 Evidence

 PASS   rest-client  packages/rest-client/src/generators/bump-version/generator.spec.ts
  bump-version generator
    √ should throw a TypeError if version is not a number (34 ms)
    √ should throw an error if the endpoint doesn't exist (3 ms)
    √ should throw an error if the new version is not higher (4 ms)
    √ should generate the new version of the endpoint (345 ms)
    √ should determine new version based on existing versions if --endpointVersion is omitted (164 ms)
    √ should respect --endpointVersion (169 ms)
    √ should update any version numbers in the code (161 ms)

Test Suites: 1 passed, 1 total
Tests:       7 passed, 7 total
Snapshots:   3 passed, 3 total
Time:        5.78 s, estimated 8 s

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
