### PR TITLE
fix(multiple) Fix/5962 windows compatibility

### DIFF
--- a/packages/common/core/src/lib/normalize-options.spec.ts
+++ b/packages/common/core/src/lib/normalize-options.spec.ts
@@ -1,5 +1,6 @@
 import { Tree } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import path from 'path';
 
 import { normalizeOptions } from '.';
 
@@ -36,8 +37,8 @@ describe('normalize', () => {
                 name: 'some-lib',
                 directory: 'subdir',
                 projectName: 'subdir-some-lib',
-                projectRoot: 'subdir/some-lib',
-                projectDirectory: 'subdir/some-lib',
+                projectRoot: path.join('subdir', 'some-lib'),
+                projectDirectory: path.join('subdir', 'some-lib'),
                 parsedTags: [],
             });
         });
@@ -55,7 +56,7 @@ describe('normalize', () => {
                 {
                     directory: 'subdir',
                     name: 'subdir-some-lib',
-                    root: 'subdir/some-lib',
+                    root: path.join('subdir', 'some-lib'),
                 },
             ],
         ])(

--- a/packages/next/src/generators/init/generator.spec.ts
+++ b/packages/next/src/generators/init/generator.spec.ts
@@ -226,9 +226,12 @@ describe('next install generator', () => {
             await generator(tree, options);
 
             const tsconfig = readJson(tree, 'next-app/tsconfig.json');
-            expect(tsconfig?.include).toContain('next.config.js');
+            expect(tsconfig?.include).toContain('**/*.ts');
+            expect(tsconfig?.include).toContain('**/*.tsx');
             expect(tsconfig?.include).toContain('**/*.js');
+            expect(tsconfig?.include).toContain('**/*.jsx');
             expect(tsconfig?.include).toContain('next-env.d.ts');
+            expect(tsconfig?.include).toContain('next.config.js');
 
             const tsconfigSpec = readJson(tree, 'next-app/tsconfig.spec.json');
             expect(tsconfigSpec?.include).toContain('jest.config.ts');

--- a/packages/next/src/generators/init/utils/tsconfig.ts
+++ b/packages/next/src/generators/init/utils/tsconfig.ts
@@ -7,14 +7,13 @@ const updateTsConfig = (
     filePath: string,
     includesFiles?: string[],
 ): void => {
-    updateJson(tree, filePath, tsconfig => {
-        const update = tsconfig;
-        const children = tree.children(path.join(project.sourceRoot, 'src'));
-        if (
-            children.filter(child =>
-                tree.exists(path.join(project.sourceRoot, 'src', child)),
-            ).length === 0
-        ) {
+    updateJson(tree, filePath, tsConfig => {
+        const update = tsConfig;
+        const sourceFolder = path.join(project.sourceRoot, 'src');
+        const filesInSource = tree
+            .children(sourceFolder)
+            .filter(child => tree.exists(path.join(sourceFolder, child)));
+        if (filesInSource.length === 0) {
             update.include = update.include.map((fileName: string) => {
                 return fileName.replace('src/', '');
             });

--- a/packages/next/src/generators/init/utils/tsconfig.ts
+++ b/packages/next/src/generators/init/utils/tsconfig.ts
@@ -9,12 +9,16 @@ const updateTsConfig = (
 ): void => {
     updateJson(tree, filePath, tsconfig => {
         const update = tsconfig;
-        if (tree.children(path.join(project.sourceRoot, 'src')).length === 0) {
+        const children = tree.children(path.join(project.sourceRoot, 'src'));
+        if (
+            children.filter(child =>
+                tree.exists(path.join(project.sourceRoot, 'src', child)),
+            ).length === 0
+        ) {
             update.include = update.include.map((fileName: string) => {
                 return fileName.replace('src/', '');
             });
         }
-
         update.include = [
             ...new Set([...(update.include || []), ...(includesFiles || [])]),
         ];

--- a/packages/playwright/src/generators/init/generator.spec.ts
+++ b/packages/playwright/src/generators/init/generator.spec.ts
@@ -2,6 +2,7 @@ import { tsMorphTree } from '@ensono-stacks/core';
 import { addStacksAttributes } from '@ensono-stacks/test';
 import { joinPathFragments, readJson, Tree } from '@nrwl/devkit';
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
+import path from 'path';
 import { SyntaxKind } from 'ts-morph';
 
 import generator from './generator';
@@ -52,14 +53,14 @@ describe('playwright generator', () => {
         await generator(appTree, options);
 
         // example.spec.ts to be added
-        expect(appTree.children(`${projectNameE2E}/src`)).toContain(
-            'example.spec.ts',
-        );
+        expect(
+            appTree.exists(path.join(projectNameE2E, 'src', 'example.spec.ts')),
+        ).toBeTruthy();
 
         // app.spec.ts to be removed
-        expect(appTree.children(`${projectNameE2E}/src`)).not.toContain(
-            'app.spec.ts',
-        );
+        expect(
+            appTree.exists(path.join(projectNameE2E, 'src', 'app.spec.ts')),
+        ).toBeFalsy();
 
         const project = tsMorphTree(appTree);
 

--- a/packages/playwright/src/generators/init/generator.ts
+++ b/packages/playwright/src/generators/init/generator.ts
@@ -110,8 +110,7 @@ export default async function initGenerator(
     addFiles(tree, 'files', normalizedOptionsForE2E);
 
     // remove app.spec.ts added from @mands generator
-    const { projectRoot } = normalizedOptionsForE2E;
-    tree.delete(`${projectRoot}-e2e/src/app.spec.ts`);
+    tree.delete(path.join(projectE2E, 'src', 'app.spec.ts'));
 
     // add records to gitignore
     addIgnoreEntry(tree, '.gitignore', 'Playwright', [


### PR DESCRIPTION
#### 📲 What

Changes to multiple plugins / unit tests to cater for variance between OS behaviour.

#### 🤔 Why

Numerous unit tests were failing when executed on windows

#### 🛠 How

Using path.join where applicable to resolve path related issues
Using tree.exists function where applicable to determine file presence

#### 👀 Evidence

nx run-many -t test --skip-nx-cache

    √  nx run common-core:test (20s)
    √  nx run common-test:test (23s)
    √  nx run workspace:test (26s)
    √  nx run create:test (7s)
    √  nx run azure-react:test (13s)
    √  nx run rest-client:test (16s)
    √  nx run next:test (22s)
    √  nx run playwright:test (14s)
    √  nx run azure-node:test (19s)
    √  nx run logger:test (14s)

 >  NX   Successfully ran target test for 10 projects (59s)

#### 🕵️ How to test

nx run-many -t test --skip-nx-cache

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
