### PR TITLE
fix(root): add nx version ^15.7.2 as peerDep for each plugin

### DIFF
--- a/packages/azure-node/package.json
+++ b/packages/azure-node/package.json
@@ -10,6 +10,7 @@
     },
     "peerDependencies": {
         "@nrwl/devkit": "^15.7.2",
-        "ts-morph": "^17.0.1"
+        "ts-morph": "^17.0.1",
+        "nx": "^15.7.2"
     }
 }

--- a/packages/azure-react/package.json
+++ b/packages/azure-react/package.json
@@ -10,6 +10,7 @@
     },
     "peerDependencies": {
         "@nrwl/devkit": "^15.7.2",
-        "@nrwl/react": "^15.7.2"
+        "@nrwl/react": "^15.7.2",
+        "nx": "^15.7.2"
     }
 }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -10,6 +10,7 @@
     },
     "peerDependencies": {
         "@nrwl/js": "^15.7.2",
-        "@nrwl/devkit": "^15.7.2"
+        "@nrwl/devkit": "^15.7.2",
+        "nx": "^15.7.2"
     }
 }

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -9,6 +9,7 @@
         "url": "https://github.com/amido/stacks-nx-plugins.git"
     },
     "peerDependencies": {
-        "@nrwl/devkit": "^15.7.2"
+        "@nrwl/devkit": "^15.7.2",
+        "nx": "^15.7.2"
     }
 }

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -9,7 +9,8 @@
         "url": "https://github.com/amido/stacks-nx-plugins.git"
     },
     "peerDependencies": {
-        "@nrwl/devkit": "^15.7.2"
+        "@nrwl/devkit": "^15.7.2",
+        "nx": "^15.7.2"
     },
     "dependencies": {
         "@mands/nx-playwright": "*"

--- a/packages/rest-client/package.json
+++ b/packages/rest-client/package.json
@@ -10,6 +10,7 @@
     },
     "peerDependencies": {
         "@nrwl/js": "^15.7.2",
-        "@nrwl/devkit": "^15.7.2"
+        "@nrwl/devkit": "^15.7.2",
+        "nx": "^15.7.2"
     }
 }

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -10,6 +10,7 @@
     },
     "peerDependencies": {
         "@nrwl/workspace": "^15.7.2",
-        "@nrwl/devkit": "^15.7.2"
+        "@nrwl/devkit": "^15.7.2",
+        "nx": "^15.7.2"
     }
 }


### PR DESCRIPTION
#### 📲 What

Expect certain v15 of nx dependancy in each plugin.

#### 🤔 Why

To prevent higher versions being accepted for usage with our plugins (otherwise they will break until v16 migration is complete)

#### 🛠 How

This change will prevent new installations if an unwanted nx version is attempted to be used.

#### 👀 Evidence

Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR

#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
