### PR TITLE
fix(rest-client): fix various misc bugs with openapi-client

### DIFF
--- a/packages/rest-client/src/generators/openapi-client/generator.spec.ts
+++ b/packages/rest-client/src/generators/openapi-client/generator.spec.ts
@@ -35,6 +35,19 @@ describe('openapi-client generator', () => {
         );
     });
 
+    it('should throw an error if directory specified', async () => {
+        tree.delete('test.yaml');
+        tree.write('openapi/test.yaml', '');
+        await expect(
+            generator(tree, {
+                ...options,
+                schema: './openapi',
+            }),
+        ).rejects.toThrowError(
+            'Provided schema does not exist in the workspace. Please check and try again',
+        );
+    });
+
     it('should delete default src lib', async () => {
         await generator(tree, options);
 

--- a/packages/rest-client/src/generators/openapi-client/generator.ts
+++ b/packages/rest-client/src/generators/openapi-client/generator.ts
@@ -32,7 +32,7 @@ export default async function generate(
     if (
         !options.schema ||
         !tree.exists(options.schema) ||
-        !fileExists(options.schema)
+        !tree.isFile(options.schema)
     ) {
         throw new Error(
             'Provided schema does not exist in the workspace. Please check and try again.',

--- a/packages/rest-client/src/generators/openapi-client/generator.ts
+++ b/packages/rest-client/src/generators/openapi-client/generator.ts
@@ -13,6 +13,7 @@ import {
 } from '@nrwl/devkit';
 import { libraryGenerator } from '@nrwl/js';
 import { runTasksInSerial } from '@nrwl/workspace/src/utilities/run-tasks-in-serial';
+import { fileExists } from 'nx/src/utils/fileutils';
 import path from 'path';
 
 import {
@@ -28,7 +29,11 @@ export default async function generate(
     tree: Tree,
     options: OpenapiClientGeneratorSchema,
 ) {
-    if (!tree.exists(options.schema)) {
+    if (
+        !options.schema ||
+        !tree.exists(options.schema) ||
+        !fileExists(options.schema)
+    ) {
         throw new Error(
             'Provided schema does not exist in the workspace. Please check and try again.',
         );
@@ -76,6 +81,7 @@ export default async function generate(
                 '@faker-js/faker': FAKERJS_VERSION,
             },
         ),
+        () => execAsync('npm i -g orval -D', project.root) as Promise<void>,
         () =>
             execAsync(
                 'orval --config ./orval.config.js',

--- a/packages/rest-client/src/generators/openapi-client/schema.json
+++ b/packages/rest-client/src/generators/openapi-client/schema.json
@@ -20,7 +20,8 @@
             "type": "string",
             "description": "Provide the path to your openapi schema, relative to the root of your workspace.",
             "alias": "s",
-            "x-prompt": "What is the relative path to your openapi schema?"
+            "x-prompt": "What is the relative path to your openapi schema?",
+            "pattern": "^[a-zA-Z0-9_/.-]+$"
         },
         "zod": {
             "type": "boolean",

--- a/packages/rest-client/src/generators/openapi-client/schema.json
+++ b/packages/rest-client/src/generators/openapi-client/schema.json
@@ -2,7 +2,8 @@
     "$schema": "http://json-schema.org/schema",
     "cli": "nx",
     "$id": "OpenapiClient",
-    "title": "",
+    "title": "Ensono Stacks Rest Client Openapi Client Generator",
+    "description": "The @ensono-stacks/rest-client:openapi-client generator will create types, axios client, stubs and validation from an openapi spec, as a new library for an existing project",
     "type": "object",
     "properties": {
         "name": {


### PR DESCRIPTION
#### 📲 What

Issue 1: nx g openapi-client --help
Description of plugin is undefined

Issue 2: What is the relative path to you openapi schema?
Accepts no value, leading to the generator hanging

Issue 3: >  NX   'orval' is not recognized as an internal or external command
When running the generator the following message is displayed

Issue 4: Yaml path input
Specifying a directory will copy across that whole directory into the generated library and put this directory as the target in both orval and zod configs.
Need to verify that the input path is an actual file first of all

#### 🤔 Why

These are required to fulfil the completion of and acceptable solution for this generator.

#### 🛠 How

Added extra checks in logic to account for such scenarios.

#### 👀 Evidence

Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR

#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
