### PR TITLE
fix(common-core): set tslib dep to ^2.3.0 matching other plugins and use cases

### DIFF
--- a/packages/common/core/package.json
+++ b/packages/common/core/package.json
@@ -4,7 +4,7 @@
     "type": "commonjs",
     "dependencies": {
         "ts-morph": "17.0.1",
-        "tslib": "2.4.1",
+        "tslib": "^2.3.0",
         "deepmerge": "^4.3.0",
         "minimatch": "^6.2.0"
     },


### PR DESCRIPTION
#### 📲 What

set tslib dep to ^2.3.0 matching other plugins and use cases

#### 🤔 Why

Prevent unwanted warnings when npm i e.g. cypress plugin

#### 🛠 How

Set to ^2.3.0 in package.json

#### 👀 Evidence

Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR

#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
