### PR TITLE
fix(root): temp change workflow to release as premajor for v2

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -41,7 +41,7 @@ jobs:
 
     - name: Version
       shell: bash
-      run: npx nx affected --target=version --base=last-prerelease --configuration=prerelease --preid="alpha-${{ github.run_number }}" --parallel=1
+      run: npx nx affected --target=version --base=last-prerelease --configuration=prerelease --releaseAs=premajor --preid="alpha-${{ github.run_number }}" --parallel=1
       env:
         NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}

--- a/e2e/azure-react-e2e/project.json
+++ b/e2e/azure-react-e2e/project.json
@@ -4,16 +4,16 @@
     "projectType": "application",
     "sourceRoot": "e2e/azure-react-e2e/src",
     "targets": {
-        "e2e": {
-            "executor": "@ensono-stacks/e2e:e2e",
-            "options": {
-                "verdaccioConfig": ".verdaccio/config.yml",
-                "jestOptions": {
-                    "jestConfig": "e2e/azure-react-e2e/jest.config.ts",
-                    "passWithNoTests": true
-                }
-            }
-        }
+        // "e2e": {
+        //     "executor": "@ensono-stacks/e2e:e2e",
+        //     "options": {
+        //         "verdaccioConfig": ".verdaccio/config.yml",
+        //         "jestOptions": {
+        //             "jestConfig": "e2e/azure-react-e2e/jest.config.ts",
+        //             "passWithNoTests": true
+        //         }
+        //     }
+        // }
     },
     "tags": ["e2e"],
     "implicitDependencies": ["azure-react", "create", "workspace"]

--- a/packages/azure-react/project.json
+++ b/packages/azure-react/project.json
@@ -37,52 +37,52 @@
                 ]
             }
         },
-        "lint": {
-            "executor": "@nrwl/linter:eslint",
-            "outputs": ["{options.outputFile}"],
-            "options": {
-                "lintFilePatterns": [
-                    "packages/azure-react/**/*.ts",
-                    "packages/azure-react/generators.json",
-                    "packages/azure-react/executors.json",
-                    "packages/azure-react/package.json"
-                ]
-            }
-        },
-        "test": {
-            "executor": "@nrwl/jest:jest",
-            "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
-            "options": {
-                "jestConfig": "packages/azure-react/jest.config.ts",
-                "passWithNoTests": true
-            }
-        },
-        "version-donotrun": {
-            "executor": "@jscutlery/semver:version",
-            "options": {
-                "trackDeps": true,
-                "dryRun": true,
-                "skipRootChangelog": true,
-                "skipProjectChangelog": true,
-                "commitMessageFormat": "chore(${projectName}): release version ${version} [skip ci]"
-            },
-            "configurations": {
-                "prerelease": {
-                    "dryRun": false,
-                    "noVerify": true,
-                    "releaseAs": "prerelease",
-                    "preid": "alpha",
-                    "push": true,
-                    "postTargets": ["azure-react:publish:prerelease"]
-                },
-                "release": {
-                    "dryRun": false,
-                    "noVerify": true,
-                    "push": true,
-                    "postTargets": ["azure-react:publish", "azure-react:github"]
-                }
-            }
-        },
+        // "lint": {
+        //     "executor": "@nrwl/linter:eslint",
+        //     "outputs": ["{options.outputFile}"],
+        //     "options": {
+        //         "lintFilePatterns": [
+        //             "packages/azure-react/**/*.ts",
+        //             "packages/azure-react/generators.json",
+        //             "packages/azure-react/executors.json",
+        //             "packages/azure-react/package.json"
+        //         ]
+        //     }
+        // },
+        // "test": {
+        //     "executor": "@nrwl/jest:jest",
+        //     "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+        //     "options": {
+        //         "jestConfig": "packages/azure-react/jest.config.ts",
+        //         "passWithNoTests": true
+        //     }
+        // },
+        // "version": {
+        //     "executor": "@jscutlery/semver:version",
+        //     "options": {
+        //         "trackDeps": true,
+        //         "dryRun": true,
+        //         "skipRootChangelog": true,
+        //         "skipProjectChangelog": true,
+        //         "commitMessageFormat": "chore(${projectName}): release version ${version} [skip ci]"
+        //     },
+        //     "configurations": {
+        //         "prerelease": {
+        //             "dryRun": false,
+        //             "noVerify": true,
+        //             "releaseAs": "prerelease",
+        //             "preid": "alpha",
+        //             "push": true,
+        //             "postTargets": ["azure-react:publish:prerelease"]
+        //         },
+        //         "release": {
+        //             "dryRun": false,
+        //             "noVerify": true,
+        //             "push": true,
+        //             "postTargets": ["azure-react:publish", "azure-react:github"]
+        //         }
+        //     }
+        // },
         "publish": {
             "executor": "ngx-deploy-npm:deploy",
             "options": {

--- a/packages/azure-react/project.json
+++ b/packages/azure-react/project.json
@@ -57,7 +57,7 @@
                 "passWithNoTests": true
             }
         },
-        "version": {
+        "version-donotrun": {
             "executor": "@jscutlery/semver:version",
             "options": {
                 "trackDeps": true,


### PR DESCRIPTION
#### 📲 What

Set workflow to releaseAs=premajor so we get v2-alpha versions.

Also comment out azure-react lint, test and version targets so they don't run as plugin is not used.

#### 🤔 Why

Why it's needed, background context.

#### 🛠 How

More in-depth discussion of the change or implementation.

#### 👀 Evidence

Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR

#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
