### PR TITLE
fix(create): add logic to normalise setting e2eTestRunner to none if playwright or cypress

### DIFF
--- a/e2e/create-e2e/tests/create.spec.ts
+++ b/e2e/create-e2e/tests/create.spec.ts
@@ -192,7 +192,7 @@ describe('create', () => {
     it('can install with playwright set as e2eTestRunner', async () => {
         const run = () =>
             execSync(
-                'npx --yes @ensono-stacks/create-stacks-workspace@latest proj --business.company=Ensono --business.domain=Stacks --business.component=Nx --cloud.platform=azure --cloud.region=euw --domain.internal=nonprod.amidostacks.com --domain.external=prod.amidostacks.com --terraform.group=tf-group --terraform.storage=tf-storage --terraform.container=tf-container --vcs.type=github --preset=apps --appName=test-app --e2eTestRunner=playwright --no-nxCloud --skipGit --no-interactive --verbose',
+                'npx --yes @ensono-stacks/create-stacks-workspace@latest proj --business.company=Ensono --business.domain=Stacks --business.component=Nx --cloud.platform=azure --cloud.region=euw --domain.internal=nonprod.amidostacks.com --domain.external=prod.amidostacks.com --terraform.group=tf-group --terraform.storage=tf-storage --terraform.container=tf-container --vcs.type=github --preset=next --appName=test-app --e2eTestRunner=playwright --no-nxCloud --skipGit --no-interactive --verbose',
                 {
                     cwd: temporaryDirectory,
                     stdio: 'inherit',

--- a/e2e/create-e2e/tests/create.spec.ts
+++ b/e2e/create-e2e/tests/create.spec.ts
@@ -192,7 +192,7 @@ describe('create', () => {
     it('can install with playwright set as e2eTestRunner', async () => {
         const run = () =>
             execSync(
-                'npx --yes @ensono-stacks/create-stacks-workspace@latest proj --business.company=Ensono --business.domain=Stacks --business.component=Nx --cloud.platform=azure --cloud.region=euw --domain.internal=nonprod.amidostacks.com --domain.external=prod.amidostacks.com --terraform.group=tf-group --terraform.storage=tf-storage --terraform.container=tf-container --vcs.type=github --preset=apps --e2eTestRunner=playwright --no-nxCloud --skipGit --no-interactive --verbose',
+                'npx --yes @ensono-stacks/create-stacks-workspace@latest proj --business.company=Ensono --business.domain=Stacks --business.component=Nx --cloud.platform=azure --cloud.region=euw --domain.internal=nonprod.amidostacks.com --domain.external=prod.amidostacks.com --terraform.group=tf-group --terraform.storage=tf-storage --terraform.container=tf-container --vcs.type=github --preset=apps --appName=testApp --e2eTestRunner=playwright --no-nxCloud --skipGit --no-interactive --verbose',
                 {
                     cwd: temporaryDirectory,
                     stdio: 'inherit',
@@ -210,7 +210,7 @@ describe('create', () => {
     it('can install with cypress set as e2eTestRunner', async () => {
         const run = () =>
             execSync(
-                'npx --yes @ensono-stacks/create-stacks-workspace proj --business.company=Ensono --business.domain=Stacks --business.component=Nx --cloud.platform=azure --cloud.region=euw --domain.internal=nonprod.amidostacks.com --domain.external=prod.amidostacks.com --terraform.group=tf-group --terraform.storage=tf-storage --terraform.container=tf-container --vcs.type=github --preset=apps --e2eTestRunner=cypress --no-nxCloud --skipGit --no-interactive --verbose',
+                'npx --yes @ensono-stacks/create-stacks-workspace proj --business.company=Ensono --business.domain=Stacks --business.component=Nx --cloud.platform=azure --cloud.region=euw --domain.internal=nonprod.amidostacks.com --domain.external=prod.amidostacks.com --terraform.group=tf-group --terraform.storage=tf-storage --terraform.container=tf-container --vcs.type=github --preset=apps --appName=testApp --e2eTestRunner=cypress --no-nxCloud --skipGit --no-interactive --verbose',
                 {
                     cwd: temporaryDirectory,
                     stdio: 'inherit',

--- a/e2e/create-e2e/tests/create.spec.ts
+++ b/e2e/create-e2e/tests/create.spec.ts
@@ -188,4 +188,40 @@ describe('create', () => {
             ),
         ).not.toThrow();
     });
+
+    it('can install with playwright set as e2eTestRunner', async () => {
+        const run = () =>
+            execSync(
+                'npx --yes @ensono-stacks/create-stacks-workspace@latest proj --business.company=Ensono --business.domain=Stacks --business.component=Nx --cloud.platform=azure --cloud.region=euw --domain.internal=nonprod.amidostacks.com --domain.external=prod.amidostacks.com --terraform.group=tf-group --terraform.storage=tf-storage --terraform.container=tf-container --vcs.type=github --preset=apps --e2eTestRunner=playwright --no-nxCloud --skipGit --no-interactive --verbose',
+                {
+                    cwd: temporaryDirectory,
+                    stdio: 'inherit',
+                    env: {
+                        ...process.env,
+                        npm_config_cache: cacheDirectory,
+                        HUSKY: '0',
+                    },
+                },
+            );
+
+        expect(() => run()).not.toThrow();
+    });
+
+    it('can install with cypress set as e2eTestRunner', async () => {
+        const run = () =>
+            execSync(
+                'npx --yes @ensono-stacks/create-stacks-workspace proj --business.company=Ensono --business.domain=Stacks --business.component=Nx --cloud.platform=azure --cloud.region=euw --domain.internal=nonprod.amidostacks.com --domain.external=prod.amidostacks.com --terraform.group=tf-group --terraform.storage=tf-storage --terraform.container=tf-container --vcs.type=github --preset=apps --e2eTestRunner=cypress --no-nxCloud --skipGit --no-interactive --verbose',
+                {
+                    cwd: temporaryDirectory,
+                    stdio: 'inherit',
+                    env: {
+                        ...process.env,
+                        npm_config_cache: cacheDirectory,
+                        HUSKY: '0',
+                    },
+                },
+            );
+
+        expect(() => run()).not.toThrow();
+    });
 });

--- a/e2e/create-e2e/tests/create.spec.ts
+++ b/e2e/create-e2e/tests/create.spec.ts
@@ -210,7 +210,7 @@ describe('create', () => {
     it('can install with cypress set as e2eTestRunner', async () => {
         const run = () =>
             execSync(
-                'npx --yes @ensono-stacks/create-stacks-workspace@latest proj --business.company=Ensono --business.domain=Stacks --business.component=Nx --cloud.platform=azure --cloud.region=euw --domain.internal=nonprod.amidostacks.com --domain.external=prod.amidostacks.com --terraform.group=tf-group --terraform.storage=tf-storage --terraform.container=tf-container --vcs.type=github --preset=apps --appName=test-app --e2eTestRunner=cypress --no-nxCloud --skipGit --no-interactive --verbose',
+                'npx --yes @ensono-stacks/create-stacks-workspace@latest proj --business.company=Ensono --business.domain=Stacks --business.component=Nx --cloud.platform=azure --cloud.region=euw --domain.internal=nonprod.amidostacks.com --domain.external=prod.amidostacks.com --terraform.group=tf-group --terraform.storage=tf-storage --terraform.container=tf-container --vcs.type=github --preset=next --appName=test-app --e2eTestRunner=cypress --no-nxCloud --skipGit --no-interactive --verbose',
                 {
                     cwd: temporaryDirectory,
                     stdio: 'inherit',

--- a/e2e/create-e2e/tests/create.spec.ts
+++ b/e2e/create-e2e/tests/create.spec.ts
@@ -192,7 +192,7 @@ describe('create', () => {
     it('can install with playwright set as e2eTestRunner', async () => {
         const run = () =>
             execSync(
-                'npx --yes @ensono-stacks/create-stacks-workspace@latest proj --business.company=Ensono --business.domain=Stacks --business.component=Nx --cloud.platform=azure --cloud.region=euw --domain.internal=nonprod.amidostacks.com --domain.external=prod.amidostacks.com --terraform.group=tf-group --terraform.storage=tf-storage --terraform.container=tf-container --vcs.type=github --preset=apps --appName=testApp --e2eTestRunner=playwright --no-nxCloud --skipGit --no-interactive --verbose',
+                'npx --yes @ensono-stacks/create-stacks-workspace@latest proj --business.company=Ensono --business.domain=Stacks --business.component=Nx --cloud.platform=azure --cloud.region=euw --domain.internal=nonprod.amidostacks.com --domain.external=prod.amidostacks.com --terraform.group=tf-group --terraform.storage=tf-storage --terraform.container=tf-container --vcs.type=github --preset=apps --appName=test-app --e2eTestRunner=playwright --no-nxCloud --skipGit --no-interactive --verbose',
                 {
                     cwd: temporaryDirectory,
                     stdio: 'inherit',
@@ -210,7 +210,7 @@ describe('create', () => {
     it('can install with cypress set as e2eTestRunner', async () => {
         const run = () =>
             execSync(
-                'npx --yes @ensono-stacks/create-stacks-workspace proj --business.company=Ensono --business.domain=Stacks --business.component=Nx --cloud.platform=azure --cloud.region=euw --domain.internal=nonprod.amidostacks.com --domain.external=prod.amidostacks.com --terraform.group=tf-group --terraform.storage=tf-storage --terraform.container=tf-container --vcs.type=github --preset=apps --appName=testApp --e2eTestRunner=cypress --no-nxCloud --skipGit --no-interactive --verbose',
+                'npx --yes @ensono-stacks/create-stacks-workspace@latest proj --business.company=Ensono --business.domain=Stacks --business.component=Nx --cloud.platform=azure --cloud.region=euw --domain.internal=nonprod.amidostacks.com --domain.external=prod.amidostacks.com --terraform.group=tf-group --terraform.storage=tf-storage --terraform.container=tf-container --vcs.type=github --preset=apps --appName=test-app --e2eTestRunner=cypress --no-nxCloud --skipGit --no-interactive --verbose',
                 {
                     cwd: temporaryDirectory,
                     stdio: 'inherit',

--- a/packages/create/bin/dependencies.ts
+++ b/packages/create/bin/dependencies.ts
@@ -24,7 +24,7 @@ export function normaliseForwardedArgv(
     updatedForwardArgv['preset'] =
         forwardArgv['preset'] === 'next' ? 'apps' : forwardArgv['preset'];
 
-    // As playwright is not supported by the Nx generator for e2eTestRunner, we pass none to proceed and later install it ourselves as part of Stacks Playwright plugin.
+    // As we have our own playwright and cypress implementations, we pass in none for the initial Nx create workspace to avoid potential conflict/errors etc.
     updatedForwardArgv['e2eTestRunner'] =
         updatedForwardArgv['e2eTestRunner'] === 'playwright' ||
         updatedForwardArgv['e2eTestRunner'] === 'cypress'

--- a/packages/create/bin/dependencies.ts
+++ b/packages/create/bin/dependencies.ts
@@ -23,6 +23,12 @@ export function normaliseForwardedArgv(
     const updatedForwardArgv = forwardArgv;
     updatedForwardArgv['preset'] =
         forwardArgv['preset'] === 'next' ? 'apps' : forwardArgv['preset'];
+
+    // As playwright is not supported by the Nx generator for e2eTestRunner, we pass none to proceed and later install it ourselves as part of Stacks Playwright plugin.
+    updatedForwardArgv['e2eTestRunner'] =
+        updatedForwardArgv['e2eTestRunner'] === 'playwright'
+            ? 'none'
+            : updatedForwardArgv['e2eTestRunner'];
     return updatedForwardArgv;
 }
 

--- a/packages/create/bin/dependencies.ts
+++ b/packages/create/bin/dependencies.ts
@@ -26,7 +26,8 @@ export function normaliseForwardedArgv(
 
     // As playwright is not supported by the Nx generator for e2eTestRunner, we pass none to proceed and later install it ourselves as part of Stacks Playwright plugin.
     updatedForwardArgv['e2eTestRunner'] =
-        updatedForwardArgv['e2eTestRunner'] === 'playwright'
+        updatedForwardArgv['e2eTestRunner'] === 'playwright' ||
+        updatedForwardArgv['e2eTestRunner'] === 'cypress'
             ? 'none'
             : updatedForwardArgv['e2eTestRunner'];
     return updatedForwardArgv;


### PR DESCRIPTION
[6413](https://dev.azure.com/amido-dev/Amido-Stacks/_workitems/edit/6413)

#### 📲 What

Ensure none is passed for e2eTestRunner if playwright or cypress selected.

#### 🤔 Why

As we have our own playwright and cypress implementations, we need to pass in as none.

#### 🛠 How

Logic added to the create script args normalise method to ensure expected behaviour.

#### 👀 Evidence

Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR

#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
