### PR TITLE
fix(common-core): read package json scope name for executed workspace

### DIFF
--- a/packages/common/core/src/utils/hasGeneratorExecuted.ts
+++ b/packages/common/core/src/utils/hasGeneratorExecuted.ts
@@ -1,4 +1,4 @@
-import { getWorkspaceLayout, Tree, updateJson } from '@nx/devkit';
+import { getWorkspaceLayout, readJson, Tree, updateJson } from '@nx/devkit';
 import chalk from 'chalk';
 
 import {
@@ -94,13 +94,24 @@ export function hasGeneratorExecutedForWorkspace(
     const generatorExecuted =
         stacksExecutedGenerators.workspace.includes(generatorName);
 
-    const workspace = getWorkspaceLayout(tree);
+    const getNpmScope = () => {
+        const workspace = getWorkspaceLayout(tree);
+        // Code copied from Nx -> packages/workspace/src/utilities/get-import-path.ts
+        if (workspace.npmScope) {
+            return workspace.npmScope;
+        }
+        const { name } = tree.exists('package.json')
+            ? readJson(tree, 'package.json')
+            : { name: null };
+
+        return name.startsWith('@') ? name.split('/')[0].slice(1) : null;
+    };
 
     if (generatorExecuted) {
         console.log(
             '\n',
             chalk.yellow`This generator has already been executed for the workspace`,
-            chalk.magenta`${workspace.npmScope}.`,
+            chalk.magenta`${getNpmScope()}.`,
             chalk.yellow`No changes made.`,
             '\n',
         );


### PR DESCRIPTION
[6423](https://dev.azure.com/amido-dev/Amido-Stacks/_workitems/edit/6423)

#### 📲 What

Read package.json for workspace scope name for logging out in message.

#### 🤔 Why

npmScope attribute is no longer present inside nx.json

#### 🛠 How

Read package.json name attribute and slice.

#### 👀 Evidence

Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR

#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
