### PR TITLE
feat(workspace:init): add eslint a11y plugin to eslint config

### DIFF
--- a/packages/workspace/src/generators/init/generator.spec.ts
+++ b/packages/workspace/src/generators/init/generator.spec.ts
@@ -72,6 +72,7 @@ describe('init generator', () => {
                         '@typescript-eslint',
                         'import',
                         'security',
+                        'jsx-a11y',
                     ],
                     overrides: expect.arrayContaining([
                         expect.objectContaining({

--- a/packages/workspace/src/generators/init/utils/eslint.ts
+++ b/packages/workspace/src/generators/init/utils/eslint.ts
@@ -25,7 +25,13 @@ function stacksEslintConfig(tree: Tree): Linter.Config {
     return {
         root: true,
         ignorePatterns: ['**/*'],
-        plugins: ['@typescript-eslint', '@nx', 'import', 'security', "jsx-a11y"],
+        plugins: [
+            '@typescript-eslint',
+            '@nx',
+            'import',
+            'security',
+            "jsx-a11y"
+        ],
         parser: '@typescript-eslint/parser',
         extends: [
             'airbnb/base',

--- a/packages/workspace/src/generators/init/utils/eslint.ts
+++ b/packages/workspace/src/generators/init/utils/eslint.ts
@@ -30,7 +30,7 @@ function stacksEslintConfig(tree: Tree): Linter.Config {
             '@nx',
             'import',
             'security',
-            "jsx-a11y"
+            'jsx-a11y',
         ],
         parser: '@typescript-eslint/parser',
         extends: [

--- a/packages/workspace/src/generators/init/utils/eslint.ts
+++ b/packages/workspace/src/generators/init/utils/eslint.ts
@@ -25,7 +25,7 @@ function stacksEslintConfig(tree: Tree): Linter.Config {
     return {
         root: true,
         ignorePatterns: ['**/*'],
-        plugins: ['@typescript-eslint', '@nx', 'import', 'security'],
+        plugins: ['@typescript-eslint', '@nx', 'import', 'security', "jsx-a11y"],
         parser: '@typescript-eslint/parser',
         extends: [
             'airbnb/base',
@@ -35,6 +35,7 @@ function stacksEslintConfig(tree: Tree): Linter.Config {
             'plugin:import/recommended',
             'plugin:import/typescript',
             'plugin:security/recommended',
+            "plugin:jsx-a11y/recommended",
         ],
         settings: {
             'import/resolver': {


### PR DESCRIPTION
#### 📲 What

A description of the change.
add eslint config to enable a11y checks 
https://dev.azure.com/amido-dev/Amido-Stacks/_workitems/edit/6383

#### 🤔 Why
so that apps generated using stacks come with dev-time a11y out of the box

Why it's needed, background context.

#### 🛠 How

More in-depth discussion of the change or implementation.

#### 👀 Evidence
refer to screenshots in ADO

#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
