### PR TITLE
Prevent NX from running in interactive mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,9 @@ jobs:
 
     - name: Version
       shell: bash
-      run: npx nx affected --target=version --base=last-release --configuration=release --parallel=1
+      run: |
+        export CI=true
+        npx nx affected --target=version --base=last-release --configuration=release --parallel=1
       env:
         NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}


### PR DESCRIPTION
#### 📲 What

Added new enviornment variable, CI

#### 🤔 Why

The command `npx nx affected` expects to be run in an interactive session but in GHA there is no tty for this

#### 🛠 How

Added `export CI=true` to the job

#### 👀 Evidence

Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR

#### 🕵️ How to test

This has not been tested on a branch as it is restricted to running on the master branch

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
