### PR TITLE
fix(common-core): use getNpmScope function to get correct scope

### DIFF
--- a/e2e/workspace-e2e/tests/__snapshots__/workspace.spec.ts.snap
+++ b/e2e/workspace-e2e/tests/__snapshots__/workspace.spec.ts.snap
@@ -72,7 +72,7 @@ exports[`workspace updates the eslintrc.json 1`] = `
             "pathGroups": [
               {
                 "group": "internal",
-                "pattern": "@undefined/**",
+                "pattern": "@proj/**",
               },
             ],
           },

--- a/packages/common/core/src/utils/hasGeneratorExecuted.ts
+++ b/packages/common/core/src/utils/hasGeneratorExecuted.ts
@@ -7,6 +7,18 @@ import {
 } from './tagExecutedGenerator';
 import { readStacksExecutedGenerators } from '../lib/stacks';
 
+export function getNpmScope(tree: Tree) {
+    const workspace = getWorkspaceLayout(tree);
+    if (workspace.npmScope) {
+        return workspace.npmScope;
+    }
+    const { name } = tree.exists('package.json')
+        ? readJson(tree, 'package.json')
+        : { name: null };
+
+    return name.startsWith('@') ? name.split('/')[0].slice(1) : null;
+}
+
 export function isGeneratorInExecutedListForProject(
     tree: Tree,
     projectName: string,
@@ -94,24 +106,11 @@ export function hasGeneratorExecutedForWorkspace(
     const generatorExecuted =
         stacksExecutedGenerators.workspace.includes(generatorName);
 
-    const getNpmScope = () => {
-        const workspace = getWorkspaceLayout(tree);
-        // Code copied from Nx -> packages/workspace/src/utilities/get-import-path.ts
-        if (workspace.npmScope) {
-            return workspace.npmScope;
-        }
-        const { name } = tree.exists('package.json')
-            ? readJson(tree, 'package.json')
-            : { name: null };
-
-        return name.startsWith('@') ? name.split('/')[0].slice(1) : null;
-    };
-
     if (generatorExecuted) {
         console.log(
             '\n',
             chalk.yellow`This generator has already been executed for the workspace`,
-            chalk.magenta`${getNpmScope()}.`,
+            chalk.magenta`${getNpmScope(tree)}.`,
             chalk.yellow`No changes made.`,
             '\n',
         );

--- a/packages/workspace/src/generators/init/utils/eslint.ts
+++ b/packages/workspace/src/generators/init/utils/eslint.ts
@@ -1,8 +1,11 @@
-import { mergeEslintConfigs, updateEslintConfig } from '@ensono-stacks/core';
+import {
+    getNpmScope,
+    mergeEslintConfigs,
+    updateEslintConfig,
+} from '@ensono-stacks/core';
 import {
     Tree,
     addDependenciesToPackageJson,
-    getWorkspaceLayout,
     readRootPackageJson,
     GeneratorCallback,
 } from '@nx/devkit';
@@ -76,9 +79,7 @@ function stacksEslintConfig(tree: Tree): Linter.Config {
                             ],
                             pathGroups: [
                                 {
-                                    pattern: `@${
-                                        getWorkspaceLayout(tree).npmScope
-                                    }/**`,
+                                    pattern: `@${getNpmScope(tree)}/**`,
                                     group: 'internal',
                                 },
                             ],


### PR DESCRIPTION
#### 📲 What

Fix for 6471: Use existing getNpmScope function to get correct scope for eslint file.

#### 🤔 Why

npmScope attribute is no longer present inside nx.json

#### 🛠 How

Export and use existing `getNpmScope` function from `hasGeneratorExecuted.ts`.

We could move this function into a standalone util file but would take extra work moving and updating tests.
Would be good to get this fix in and perhaps raise and improvement task to move to separate file if required.

#### 👀 Evidence

Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR

#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
