### PR TITLE
feat(next:init): add react-axe config to generated applications

### DIFF
--- a/packages/next/src/generators/init/__snapshots__/generator.spec.ts.snap
+++ b/packages/next/src/generators/init/__snapshots__/generator.spec.ts.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`next install generator Project config executedGenerators should match the snapshot for _app.tsx file: next-app/pages/_app.tsx 1`] = `
+"import { AppProps } from 'next/app';
+import Head from 'next/head';
+import './styles.css';
+
+/**
+ * A dynamic import is used here to only load the react-axe library for a11y checks
+ * when it is not in production mode
+ * This ensures that it is only ran in local env.
+ */
+// @ts-ignore
+if (typeof window !== 'undefined' && process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line global-require
+    const axe = require('@axe-core/react'); // eslint-disable-line @typescript-eslint/no-var-requires
+    // eslint-disable-next-line global-require
+    const React = require('react'); // eslint-disable-line @typescript-eslint/no-var-requires
+    // eslint-disable-next-line global-require
+    const ReactDOM = require('react-dom'); // eslint-disable-line @typescript-eslint/no-var-requires
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    axe(React, ReactDOM, 1000);
+}
+
+function CustomApp({ Component, pageProps }: AppProps) {
+    return (
+        <>
+            <Head>
+                <title>Welcome to next-app!</title>
+            </Head>
+            <main className="app">
+                <Component {...pageProps} />
+            </main>
+        </>
+    );
+}
+
+export default CustomApp;
+"
+`;

--- a/packages/next/src/generators/init/generator.spec.ts
+++ b/packages/next/src/generators/init/generator.spec.ts
@@ -1,11 +1,25 @@
-import { addStacksAttributes } from '@ensono-stacks/test';
-import { Tree, readJson } from '@nx/devkit';
+import { tsMorphTree } from '@ensono-stacks/core';
+import {
+    addStacksAttributes,
+    checkFilesExistInTree,
+} from '@ensono-stacks/test';
+import { Tree, joinPathFragments, readJson } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { applicationGenerator } from '@nx/next';
 import { Schema as NextSchema } from '@nx/next/src/generators/application/schema';
 
 import generator from './generator';
 import { NextGeneratorSchema } from './schema';
+
+function snapshotFiles(tree, files: string[]) {
+    expect(() => checkFilesExistInTree(tree, ...files)).not.toThrowError();
+    const project = tsMorphTree(tree);
+    files.forEach(file => {
+        expect(project.addSourceFileAtPath(file).getText()).toMatchSnapshot(
+            file,
+        );
+    });
+}
 
 describe('next install generator', () => {
     let tree: Tree;
@@ -140,6 +154,14 @@ describe('next install generator', () => {
                 });
 
                 expect(gen).toBe(false);
+            });
+            it('should match the snapshot for _app.tsx file', async () => {
+                const underscoreAppFilePath = joinPathFragments(
+                    options.project,
+                    'pages',
+                    '_app.tsx',
+                );
+                snapshotFiles(tree, [underscoreAppFilePath]);
             });
         });
     });

--- a/packages/next/src/generators/init/generator.spec.ts
+++ b/packages/next/src/generators/init/generator.spec.ts
@@ -10,6 +10,7 @@ import { Schema as NextSchema } from '@nx/next/src/generators/application/schema
 
 import generator from './generator';
 import { NextGeneratorSchema } from './schema';
+import { REACT_AXE_CORE_VERSION } from '../../utils/constants';
 
 function snapshotFiles(tree, files: string[]) {
     expect(() => checkFilesExistInTree(tree, ...files)).not.toThrowError();
@@ -162,6 +163,12 @@ describe('next install generator', () => {
                     '_app.tsx',
                 );
                 snapshotFiles(tree, [underscoreAppFilePath]);
+            });
+            it('should install the react-axe package', async () => {
+                const packageJson = readJson(tree, 'package.json');
+                expect(packageJson?.devDependencies).toMatchObject({
+                    '@axe-core/react': REACT_AXE_CORE_VERSION,
+                });
             });
         });
     });

--- a/packages/next/src/generators/init/generator.ts
+++ b/packages/next/src/generators/init/generator.ts
@@ -15,6 +15,7 @@ import {
     updateProjectConfiguration,
 } from '@nx/devkit';
 import { runTasksInSerial } from '@nx/workspace/src/utilities/run-tasks-in-serial';
+import chalk from 'chalk';
 import path from 'path';
 
 import { NextGeneratorSchema } from './schema';
@@ -97,8 +98,11 @@ export default async function initGenerator(
 
     const morphTree = tsMorphTree(tree);
 
+    console.info(chalk.green`Attempting to add configuration for react-axe`);
     addReactAxeConfigToApp(project, morphTree);
-
+    console.info(
+        chalk.green`continuing execution of next:init generator after attempting to add react-axe`,
+    );
     eslintFix(project, tree);
 
     // exclude helm yaml files from initial format when generating the files

--- a/packages/next/src/generators/init/generator.ts
+++ b/packages/next/src/generators/init/generator.ts
@@ -5,6 +5,7 @@ import {
     deploymentGeneratorMessage,
     hasGeneratorExecutedForProject,
     verifyPluginCanBeInstalled,
+    tsMorphTree,
 } from '@ensono-stacks/core';
 import {
     GeneratorCallback,
@@ -19,6 +20,10 @@ import path from 'path';
 import { NextGeneratorSchema } from './schema';
 import { addEslint } from './utils/eslint';
 import { eslintFix } from './utils/eslint-fix';
+import {
+    addReactAxeConfigToApp,
+    addReactAxeDependency,
+} from './utils/react-axe';
 import updateTsConfig from './utils/tsconfig';
 
 export default async function initGenerator(
@@ -70,7 +75,10 @@ export default async function initGenerator(
         ciCoverageConfig,
     );
 
-    tasks.push(formatFilesWithEslint(options.project));
+    tasks.push(
+        formatFilesWithEslint(options.project),
+        addReactAxeDependency(tree),
+    );
 
     // update tsconfig.json
     updateTsConfig(
@@ -86,6 +94,10 @@ export default async function initGenerator(
         project,
         path.join(project.sourceRoot, 'tsconfig.spec.json'),
     );
+
+    const morphTree = tsMorphTree(tree);
+
+    addReactAxeConfigToApp(project, morphTree);
 
     eslintFix(project, tree);
 

--- a/packages/next/src/generators/init/utils/react-axe.ts
+++ b/packages/next/src/generators/init/utils/react-axe.ts
@@ -1,0 +1,85 @@
+import {
+    addDependenciesToPackageJson,
+    ProjectConfiguration,
+    joinPathFragments,
+} from '@nx/devkit';
+import { Project, SyntaxKind } from 'ts-morph';
+
+const reactAxeConfigurationCode = `
+/**
+ * A dynamic import is used here to only load the react-axe library for a11y checks
+ * when it is not in production mode
+ * This ensures that it is not unnecessarily ran in production.
+ */
+if (typeof window !== 'undefined' && process.env.NODE_ENV !== 'production' ) {
+    // eslint-disable-next-line global-require
+    const axe = require('@axe-core/react'); // eslint-disable-line @typescript-eslint/no-var-requires
+    // eslint-disable-next-line global-require
+    const React = require('react'); // eslint-disable-line @typescript-eslint/no-var-requires
+    // eslint-disable-next-line global-require
+    const ReactDOM = require('react-dom'); // eslint-disable-line @typescript-eslint/no-var-requires
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    axe(React, ReactDOM, 1000);
+}
+`;
+
+export function addReactAxeDependency(tree) {
+    return addDependenciesToPackageJson(
+        tree,
+        {},
+        {
+            '@axe-core/react': '^4.7.3',
+        },
+    );
+}
+/**
+ * adds react-axe config to _app.tsx file
+ * if the file _app.tsx doesn't exist in the project or is not where it is by convention in nextjs, it will do nothing
+ * for projects that use app directory (nextjs v13), this function will not do anything
+ * NOTE: In the default configuration of a nextjs v13 app, react-axe will need to be manually configured
+ */
+export function addReactAxeConfigToApp(
+    project: ProjectConfiguration,
+    morphTree: Project,
+) {
+    console.log('TESTTSTTST \n lifuhglwadfkuhlwadif \n skajFDGKWDJFG')
+    try {
+        const pagesDirectory = joinPathFragments(
+            project.root,
+            'pages',
+            '_app.tsx',
+        );
+        // Checks if the file _app.tsx exists in the project
+        // const isPagesDirectory =
+        //     morphTree.getSourceFile(pagesDirectory) !== undefined;
+
+        // if (isPagesDirectory) {
+        // the whole operation should fail if the _app.tsx is not found
+        const appNode = morphTree.addSourceFileAtPath(pagesDirectory);
+        // Find the line containing "function CustomApp"
+        const functionCustomAppLine = appNode
+            .getDescendantsOfKind(SyntaxKind.FunctionDeclaration)
+            .find(node => node.getName() === 'CustomApp')
+            ?.getStartLineNumber();
+
+        if (functionCustomAppLine) {
+            // Get all the lines in the source file
+            const lines = appNode.getFullText().split('\n');
+
+            // Calculate the line number to insert the new code
+            const insertLine = functionCustomAppLine - 2;
+
+            // Insert the react-axe config code
+            lines.splice(insertLine, 0, reactAxeConfigurationCode);
+
+            // Save the changes to the file.
+            appNode.replaceWithText(lines.join('\n'));
+            appNode.saveSync();
+        }
+        // }
+    } catch (error) {
+        console.error(
+            `Couldn't add the react-axe configuration to the project root file, got error: ${error}`,
+        );
+    }
+}

--- a/packages/next/src/generators/init/utils/react-axe.ts
+++ b/packages/next/src/generators/init/utils/react-axe.ts
@@ -5,6 +5,7 @@ import {
 } from '@nx/devkit';
 import { Project, SyntaxKind } from 'ts-morph';
 
+// the code that needs to be injected to _app.tsx file.
 const reactAxeConfigurationCode = `
 /**
  * A dynamic import is used here to only load the react-axe library for a11y checks
@@ -42,19 +43,13 @@ export function addReactAxeConfigToApp(
     project: ProjectConfiguration,
     morphTree: Project,
 ) {
-    console.log('TESTTSTTST \n lifuhglwadfkuhlwadif \n skajFDGKWDJFG')
     try {
         const pagesDirectory = joinPathFragments(
             project.root,
             'pages',
             '_app.tsx',
         );
-        // Checks if the file _app.tsx exists in the project
-        // const isPagesDirectory =
-        //     morphTree.getSourceFile(pagesDirectory) !== undefined;
-
-        // if (isPagesDirectory) {
-        // the whole operation should fail if the _app.tsx is not found
+        // the whole operation should fail if the _app.tsx is not found (error is Thrown by addSourceFileAtPath)
         const appNode = morphTree.addSourceFileAtPath(pagesDirectory);
         // Find the line containing "function CustomApp"
         const functionCustomAppLine = appNode

--- a/packages/next/src/generators/init/utils/react-axe.ts
+++ b/packages/next/src/generators/init/utils/react-axe.ts
@@ -11,8 +11,9 @@ const reactAxeConfigurationCode = `
 /**
  * A dynamic import is used here to only load the react-axe library for a11y checks
  * when it is not in production mode
- * This ensures that it is not unnecessarily ran in local env.
+ * This ensures that it is only ran in local env.
  */
+// @ts-ignore
 if (typeof window !== 'undefined' && process.env.NODE_ENV !== 'production' ) {
     // eslint-disable-next-line global-require
     const axe = require('@axe-core/react'); // eslint-disable-line @typescript-eslint/no-var-requires

--- a/packages/next/src/generators/init/utils/react-axe.ts
+++ b/packages/next/src/generators/init/utils/react-axe.ts
@@ -6,6 +6,8 @@ import {
 import chalk from 'chalk';
 import { Project, SyntaxKind } from 'ts-morph';
 
+import { REACT_AXE_CORE_VERSION } from '../../../utils/constants';
+
 // the code that needs to be injected to _app.tsx file.
 const reactAxeConfigurationCode = `
 /**
@@ -31,7 +33,7 @@ export function addReactAxeDependency(tree) {
         tree,
         {},
         {
-            '@axe-core/react': '^4.7.3',
+            '@axe-core/react': REACT_AXE_CORE_VERSION,
         },
     );
 }

--- a/packages/next/src/utils/constants.ts
+++ b/packages/next/src/utils/constants.ts
@@ -2,3 +2,4 @@ export const PACKAGE_JSON = 'package.json';
 export const NXTOOLS_NX_CONTAINER_VERSION = '4.0.2';
 export const NXTOOLS_NX_METADATA_VERSION = '4.0.2';
 export const JSCUTLERY_SEMVER_VERSION = '2.29.0';
+export const REACT_AXE_CORE_VERSION = '^4.7.3';


### PR DESCRIPTION
…fault

#### 📲 What

adds an a11y tool (react-axe) to all nextjs applications generated using stacks

#### 🤔 Why

for a11y enhancements

#### 🛠 How

adding 2 function calls in next:init generator; one to add the react-axe devDependency and another to ensure the necessary config for react-axe initialisation is added to _app.tsx.

#### 👀 Evidence

Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR

#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
