### PR TITLE
fix(workspace): bump msw version to avoid ts peer dep conflict

### DIFF
--- a/packages/rest-client/utils/versions.ts
+++ b/packages/rest-client/utils/versions.ts
@@ -1,5 +1,5 @@
 export const AXIOS_VERSION = '1.3.4';
 export const ORVAL_VERSION = '6.15.0';
-export const MSW_VERSION = '1.2.1';
+export const MSW_VERSION = '1.2.3';
 export const FAKERJS_VERSION = '8.0.1';
 export const ZOD_VERSION = '3.21.4';


### PR DESCRIPTION
#### 📲 What

Fix for 6434: Bump msw version to 1.2.3 which will in turn bump peer dep version of typescript and avoid conflict

#### 🤔 Why

rest-client generator fails on install

#### 🛠 How

Bump msw version in `version.ts` to `1.2.3`

#### 👀 Evidence

Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR

#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
