### PR TITLE
[6527] Rest Client Error message - incorrect message when folder does not match convention

### DIFF
--- a/packages/rest-client/src/generators/bump-version/generator.spec.ts
+++ b/packages/rest-client/src/generators/bump-version/generator.spec.ts
@@ -54,18 +54,6 @@ describe('bump-version generator', () => {
         );
     });
 
-    it('should throw an error if a folder name does not match folder convention', async () => {
-        await tree.write('endpoints/test/fakeVersion/src/index.ts', 'test');
-
-        await expect(() =>
-            generator(tree, {
-                ...options,
-            }),
-        ).rejects.toThrowError(
-            "Found a folder that does not follow convention, please follow 'v<number>'",
-        );
-    });
-
     it('should generate the new version of the endpoint', async () => {
         tree.write('fixtures/endpoints/test/v1/src/index.ts', 'test');
         await generator(tree, {
@@ -171,5 +159,17 @@ describe('bump-version generator', () => {
         expect(indexTs).toMatchSnapshot();
         expect(indexTestTs).toMatchSnapshot();
         expect(indexTypesTs).toMatchSnapshot();
+    });
+
+    it('should throw an error if a folder name does not match folder convention', async () => {
+        await tree.write('endpoints/test/fakeVersion/src/index.ts', 'test');
+
+        await expect(() =>
+            generator(tree, {
+                ...options,
+            }),
+        ).rejects.toThrowError(
+            "Found a folder that does not follow convention, please follow 'v<number>'",
+        );
     });
 });

--- a/packages/rest-client/src/generators/bump-version/generator.spec.ts
+++ b/packages/rest-client/src/generators/bump-version/generator.spec.ts
@@ -54,6 +54,18 @@ describe('bump-version generator', () => {
         );
     });
 
+    it('should throw an error if a folder name does not match folder convention', async () => {
+        await tree.write('endpoints/test/fakeVersion/src/index.ts', 'test');
+
+        await expect(() =>
+            generator(tree, {
+                ...options,
+            }),
+        ).rejects.toThrowError(
+            "Found a folder that does not follow convention, please follow 'v<number>'",
+        );
+    });
+
     it('should generate the new version of the endpoint', async () => {
         tree.write('fixtures/endpoints/test/v1/src/index.ts', 'test');
         await generator(tree, {

--- a/packages/rest-client/src/generators/bump-version/generator.spec.ts
+++ b/packages/rest-client/src/generators/bump-version/generator.spec.ts
@@ -172,4 +172,17 @@ describe('bump-version generator', () => {
             "Found a folder that does not follow convention, please follow 'v<number>'",
         );
     });
+
+    it('should throw an error if a folder name does not match folder convention', async () => {
+        await tree.write('endpoints/test/v4/src/index.ts', 'test');
+        await tree.write('endpoints/test/v3/src/index.ts', 'test');
+
+        await expect(() =>
+            generator(tree, {
+                ...options,
+            }),
+        ).rejects.toThrowError(
+            "Found a folder that does not follow convention, please follow 'v<number>'",
+        );
+    });
 });

--- a/packages/rest-client/src/generators/bump-version/generator.spec.ts
+++ b/packages/rest-client/src/generators/bump-version/generator.spec.ts
@@ -172,17 +172,4 @@ describe('bump-version generator', () => {
             "Found a folder that does not follow convention, please follow 'v<number>'",
         );
     });
-
-    it('should throw an error if a folder name does not match folder convention', async () => {
-        await tree.write('endpoints/test/v4/src/index.ts', 'test');
-        await tree.write('endpoints/test/v3/src/index.ts', 'test');
-
-        await expect(() =>
-            generator(tree, {
-                ...options,
-            }),
-        ).rejects.toThrowError(
-            "Found a folder that does not follow convention, please follow 'v<number>'",
-        );
-    });
 });

--- a/packages/rest-client/src/generators/bump-version/generator.ts
+++ b/packages/rest-client/src/generators/bump-version/generator.ts
@@ -35,7 +35,9 @@ function findLatestVersion(
         );
     }
 
-    if (children.some(folderName => versionFolderConvention.test(folderName))) {
+    if (
+        children.some(folderName => !versionFolderConvention.test(folderName))
+    ) {
         throw new Error(
             "Found a folder that does not follow convention, please follow 'v<number>'",
         );
@@ -121,11 +123,37 @@ function isRelative(parent: string, directory: string) {
     return relative && !relative.startsWith('..') && !path.isAbsolute(relative);
 }
 
+function isEndpointVersionOptionIncorrectlyPresent(
+    endpointVersion: number | undefined,
+) {
+    if (endpointVersion === undefined) {
+        return false;
+    }
+
+    if (Number.isInteger(endpointVersion)) {
+        return false;
+    }
+
+    if (Number.isNaN(endpointVersion)) {
+        return true;
+    }
+
+    return false;
+}
+
 export default async function bumpVersion(
     tree: Tree,
     optionsParameter: BumpVersionGeneratorSchema,
 ) {
     verifyPluginCanBeInstalled(tree, optionsParameter.name);
+
+    const endpointVersionOptionIncorrectlyPresent =
+        isEndpointVersionOptionIncorrectlyPresent(
+            optionsParameter.endpointVersion,
+        );
+    if (endpointVersionOptionIncorrectlyPresent) {
+        throw new TypeError(`The endpoint version needs to be a number.`);
+    }
 
     const latestVersion = findLatestVersion(tree, {
         endpointName: optionsParameter.name,

--- a/packages/rest-client/src/generators/bump-version/generator.ts
+++ b/packages/rest-client/src/generators/bump-version/generator.ts
@@ -13,14 +13,16 @@ function findLatestVersion(
     tree: Tree,
     { endpointName }: { endpointName: string },
 ): number {
+    const versionFolderConvention = /v(\d+)$/g;
     let children;
     try {
-        const versionsPath = readProjectConfiguration(
-            tree,
-            endpointName,
-        ).root.replaceAll(/v(\d+)$/g, '');
+        const versionsPath = readProjectConfiguration(tree, endpointName);
+        const versionFolderFromPath = versionsPath.root.replaceAll(
+            versionFolderConvention,
+            '',
+        );
 
-        children = tree.children(versionsPath);
+        children = tree.children(versionFolderFromPath);
     } catch {
         throw new Error(
             "Could not find previous version of the endpoint. Are you sure you don't want to generate a new endpoint?",
@@ -29,13 +31,21 @@ function findLatestVersion(
 
     if (children.length === 0) {
         throw new Error(
-            "Could not find previous version of the endpoint. Are you sure you don't want to generate a new endpoint?",
+            "No version is present for the endpoint. Are you sure you don't want to generate a new endpoint?",
+        );
+    }
+
+    if (children.some(folderName => versionFolderConvention.test(folderName))) {
+        throw new Error(
+            "Found a folder that does not follow convention, please follow 'v<number>'",
         );
     }
 
     const versions = children.map(version =>
         Number.parseInt(version.replace(/^v/i, ''), 10),
     );
+
+    console.log('versions:', versions);
 
     return Math.max(...versions);
 }

--- a/packages/rest-client/src/generators/bump-version/generator.ts
+++ b/packages/rest-client/src/generators/bump-version/generator.ts
@@ -13,12 +13,11 @@ function findLatestVersion(
     tree: Tree,
     { endpointName }: { endpointName: string },
 ): number {
-    const versionFolderConvention = /v(\d+)$/g;
     let children;
     try {
         const versionsPath = readProjectConfiguration(tree, endpointName);
         const versionFolderFromPath = versionsPath.root.replaceAll(
-            versionFolderConvention,
+            /v(\d+)$/g,
             '',
         );
 
@@ -36,7 +35,10 @@ function findLatestVersion(
     }
 
     if (
-        children.some(folderName => !versionFolderConvention.test(folderName))
+        children.some(folderName => {
+            const folderNameMatchesConvention = /v(\d+)$/.test(folderName);
+            return !folderNameMatchesConvention;
+        })
     ) {
         throw new Error(
             "Found a folder that does not follow convention, please follow 'v<number>'",

--- a/packages/rest-client/src/generators/bump-version/generator.ts
+++ b/packages/rest-client/src/generators/bump-version/generator.ts
@@ -49,8 +49,6 @@ function findLatestVersion(
         Number.parseInt(version.replace(/^v/i, ''), 10),
     );
 
-    console.log('versions:', versions);
-
     return Math.max(...versions);
 }
 


### PR DESCRIPTION
#### 📲 What

Incorrect message when folder does not match convention which leads to confusion

#### 🤔 Why

The issue is not the error itself but what is displays and that leads to confusion. We need a better message to explain why the command didn't work

#### 🛠 How

Display a message that mentions that a folder does not follow convention and presents what the convention is.

#### 👀 Evidence

No documentation needs to be changed. Added tests to check for changes

#### 🕵️ How to test

Notes for QA
Either run tests OR
follow steps in ticket: https://amido-dev.visualstudio.com/Amido-Stacks/_workitems/edit/6527

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [x] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [x] Rebased/merged with latest changes from development and re-tested?
- [x] Meeting the Coding Standards?
