### PR TITLE
fix(root): bump verdaccio from 5.32.1 → 5.32.2 to mitigate CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
                 "ts-jest": "29.1.0",
                 "ts-node": "10.9.1",
                 "typescript": "~5.4.2",
-                "verdaccio": "^5.32.1"
+                "verdaccio": "^5.32.2"
             },
             "engines": {
                 "node": "22.1.0",
@@ -8001,21 +8001,20 @@
             "dev": true
         },
         "node_modules/@verdaccio/auth": {
-            "version": "7.0.0-next-7.20",
-            "resolved": "https://registry.npmjs.org/@verdaccio/auth/-/auth-7.0.0-next-7.20.tgz",
-            "integrity": "sha512-LzzP3BWqamH396KncXX/PchP9yPpn+h2jF0LGeknHBxL66AjlcN/H/0v39fVznIszX2xSlFgJkmYX5J0Vb7i+g==",
+            "version": "8.0.0-next-8.1",
+            "resolved": "https://registry.npmjs.org/@verdaccio/auth/-/auth-8.0.0-next-8.1.tgz",
+            "integrity": "sha512-sPmHdnYuRSMgABCsTJEfz8tb/smONsWVg0g4KK2QycyYZ/A+RwZLV1JLiQb4wzu9zvS0HSloqWqkWlyNHW3mtw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@verdaccio/config": "7.0.0-next-7.20",
-                "@verdaccio/core": "7.0.0-next-7.20",
-                "@verdaccio/loaders": "7.0.0-next-7.20",
-                "@verdaccio/logger": "7.0.0-next-7.20",
-                "@verdaccio/signature": "7.0.0-next-7.5",
-                "@verdaccio/utils": "7.0.0-next-7.20",
-                "debug": "4.3.4",
+                "@verdaccio/config": "8.0.0-next-8.1",
+                "@verdaccio/core": "8.0.0-next-8.1",
+                "@verdaccio/loaders": "8.0.0-next-8.1",
+                "@verdaccio/logger": "8.0.0-next-8.1",
+                "@verdaccio/signature": "8.0.0-next-8.0",
+                "@verdaccio/utils": "7.0.1-next-8.1",
+                "debug": "4.3.7",
                 "lodash": "4.17.21",
-                "verdaccio-htpasswd": "12.0.0-next-7.20"
+                "verdaccio-htpasswd": "13.0.0-next-8.1"
             },
             "engines": {
                 "node": ">=18"
@@ -8023,24 +8022,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/verdaccio"
-            }
-        },
-        "node_modules/@verdaccio/auth/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
             }
         },
         "node_modules/@verdaccio/commons-api": {
@@ -8069,43 +8050,24 @@
             "license": "MIT"
         },
         "node_modules/@verdaccio/config": {
-            "version": "7.0.0-next-7.20",
-            "resolved": "https://registry.npmjs.org/@verdaccio/config/-/config-7.0.0-next-7.20.tgz",
-            "integrity": "sha512-5bhTnuMib25AU4LrtAraju8/SE9EXsuogX9V6Ebbt7SdyfvRG0NnzIF1WZXIv4Cqagh97h6FseelFlXAjt2+Tw==",
+            "version": "8.0.0-next-8.1",
+            "resolved": "https://registry.npmjs.org/@verdaccio/config/-/config-8.0.0-next-8.1.tgz",
+            "integrity": "sha512-goDVOH4e8xMUxjHybJpi5HwIecVFqzJ9jeNFrRUgtUUn0PtFuNMHgxOeqDKRVboZhc5HK90yed8URK/1O6VsUw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@verdaccio/core": "7.0.0-next-7.20",
-                "@verdaccio/utils": "7.0.0-next-7.20",
-                "debug": "4.3.4",
+                "@verdaccio/core": "8.0.0-next-8.1",
+                "@verdaccio/utils": "7.0.1-next-8.1",
+                "debug": "4.3.7",
                 "js-yaml": "4.1.0",
                 "lodash": "4.17.21",
                 "minimatch": "7.4.6"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=14"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/verdaccio"
-            }
-        },
-        "node_modules/@verdaccio/config/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
             }
         },
         "node_modules/@verdaccio/config/node_modules/minimatch": {
@@ -8113,7 +8075,6 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
             "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
             },
@@ -8125,42 +8086,24 @@
             }
         },
         "node_modules/@verdaccio/core": {
-            "version": "7.0.0-next-7.20",
-            "resolved": "https://registry.npmjs.org/@verdaccio/core/-/core-7.0.0-next-7.20.tgz",
-            "integrity": "sha512-U5IafCFHSoCILUd503TBTX1OgltVOOkgLjRN5m5NeLkoIuARX1tF1UQgPQd/WllkXLYxL8F07SZzDpzZOhjpiQ==",
+            "version": "8.0.0-next-8.1",
+            "resolved": "https://registry.npmjs.org/@verdaccio/core/-/core-8.0.0-next-8.1.tgz",
+            "integrity": "sha512-kQRCB2wgXEh8H88G51eQgAFK9IxmnBtkQ8sY5FbmB6PbBkyHrbGcCp+2mtRqqo36j0W1VAlfM3XzoknMy6qQnw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "ajv": "8.12.0",
-                "core-js": "3.35.0",
+                "ajv": "8.17.1",
+                "core-js": "3.37.1",
                 "http-errors": "2.0.0",
                 "http-status-codes": "2.3.0",
                 "process-warning": "1.0.0",
                 "semver": "7.6.3"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=14"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/verdaccio"
-            }
-        },
-        "node_modules/@verdaccio/core/node_modules/ajv": {
-            "version": "8.12.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-            "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2",
-                "uri-js": "^4.2.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
             }
         },
         "node_modules/@verdaccio/file-locking": {
@@ -8181,14 +8124,13 @@
             }
         },
         "node_modules/@verdaccio/loaders": {
-            "version": "7.0.0-next-7.20",
-            "resolved": "https://registry.npmjs.org/@verdaccio/loaders/-/loaders-7.0.0-next-7.20.tgz",
-            "integrity": "sha512-XTUneZXOCckZ7WO6Oxju5BA6DtOjtpb72xs0BGq/PCSwRU7bGEHAn9YWngfX8hgVVOxJfO2QHCoveDsVUYf7XA==",
+            "version": "8.0.0-next-8.1",
+            "resolved": "https://registry.npmjs.org/@verdaccio/loaders/-/loaders-8.0.0-next-8.1.tgz",
+            "integrity": "sha512-mqGCUBs862g8mICZwX8CG92p1EZ1Un0DJ2DB7+iVu2TYaEeKoHoIdafabVdiYrbOjLcAOOBrMKE1Wnn14eLxpA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@verdaccio/logger": "7.0.0-next-7.20",
-                "debug": "4.3.4",
+                "@verdaccio/logger": "8.0.0-next-8.1",
+                "debug": "4.3.7",
                 "lodash": "4.17.21"
             },
             "engines": {
@@ -8197,24 +8139,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/verdaccio"
-            }
-        },
-        "node_modules/@verdaccio/loaders/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
             }
         },
         "node_modules/@verdaccio/local-storage-legacy": {
@@ -8280,13 +8204,12 @@
             }
         },
         "node_modules/@verdaccio/logger": {
-            "version": "7.0.0-next-7.20",
-            "resolved": "https://registry.npmjs.org/@verdaccio/logger/-/logger-7.0.0-next-7.20.tgz",
-            "integrity": "sha512-LWU00eGnibV/KKt65KQOMc6VkHe23SdGs2ZfNZXpXc8RKTNY1wWt0qu2lxmqu0cOMw1Hz8C5yfpXMPdOvDPYbg==",
+            "version": "8.0.0-next-8.1",
+            "resolved": "https://registry.npmjs.org/@verdaccio/logger/-/logger-8.0.0-next-8.1.tgz",
+            "integrity": "sha512-w5kR0/umQkfH2F4PK5Fz9T6z3xz+twewawKLPTUfAgrVAOiWxcikGhhcHWhSGiJ0lPqIa+T0VYuLWMeVeDirGw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@verdaccio/logger-commons": "7.0.0-next-7.20",
+                "@verdaccio/logger-commons": "8.0.0-next-8.1",
                 "pino": "8.17.2"
             },
             "engines": {
@@ -8298,13 +8221,12 @@
             }
         },
         "node_modules/@verdaccio/logger-7": {
-            "version": "7.0.0-next-7.20",
-            "resolved": "https://registry.npmjs.org/@verdaccio/logger-7/-/logger-7-7.0.0-next-7.20.tgz",
-            "integrity": "sha512-+GVsvoptbU3umgElmVwqF1r3ZrHQELJlDI1kDFTIBGU3YW3O0EZ9vr3uThlNVCBoZBA/BhwgtCctal+I60NCSA==",
+            "version": "8.0.0-next-8.1",
+            "resolved": "https://registry.npmjs.org/@verdaccio/logger-7/-/logger-7-8.0.0-next-8.1.tgz",
+            "integrity": "sha512-V+/B1Wnct3IZ90q6HkI1a3dqbS0ds7s/5WPrS5cmBeLEw78/OGgF76XkhI2+lett7Un1CjVow7mcebOWcZ/Sqw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@verdaccio/logger-commons": "7.0.0-next-7.20",
+                "@verdaccio/logger-commons": "8.0.0-next-8.1",
                 "pino": "7.11.0"
             },
             "engines": {
@@ -8320,7 +8242,6 @@
             "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
             "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "end-of-stream": "^1.4.1",
                 "inherits": "^2.0.3",
@@ -8332,15 +8253,13 @@
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
             "integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/@verdaccio/logger-7/node_modules/pino": {
             "version": "7.11.0",
             "resolved": "https://registry.npmjs.org/pino/-/pino-7.11.0.tgz",
             "integrity": "sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "atomic-sleep": "^1.0.0",
                 "fast-redact": "^3.0.0",
@@ -8363,7 +8282,6 @@
             "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
             "integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "duplexify": "^4.1.2",
                 "split2": "^4.0.0"
@@ -8373,15 +8291,13 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
             "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/@verdaccio/logger-7/node_modules/readable-stream": {
             "version": "3.6.2",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
             "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -8396,7 +8312,6 @@
             "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
             "integrity": "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 12.13.0"
             }
@@ -8406,7 +8321,6 @@
             "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.8.0.tgz",
             "integrity": "sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "atomic-sleep": "^1.0.0"
             }
@@ -8416,22 +8330,20 @@
             "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-0.15.2.tgz",
             "integrity": "sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "real-require": "^0.1.0"
             }
         },
         "node_modules/@verdaccio/logger-commons": {
-            "version": "7.0.0-next-7.20",
-            "resolved": "https://registry.npmjs.org/@verdaccio/logger-commons/-/logger-commons-7.0.0-next-7.20.tgz",
-            "integrity": "sha512-WNRkgWlk+WDT49ydKQMMFshI/31cWOP5z1ut89b3toCifBtgwQKc6rjy75fwrsLNM8PSP3Gi7oX+2QdRtbR0mQ==",
+            "version": "8.0.0-next-8.1",
+            "resolved": "https://registry.npmjs.org/@verdaccio/logger-commons/-/logger-commons-8.0.0-next-8.1.tgz",
+            "integrity": "sha512-jCge//RT4uaK7MarhpzcJeJ5Uvtu/DbJ1wvJQyGiFe+9AvxDGm3EUFXvawLFZ0lzYhmLt1nvm7kevcc3vOm2ZQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@verdaccio/core": "7.0.0-next-7.20",
-                "@verdaccio/logger-prettify": "7.0.0-next-7.3",
+                "@verdaccio/core": "8.0.0-next-8.1",
+                "@verdaccio/logger-prettify": "8.0.0-next-8.0",
                 "colorette": "2.0.20",
-                "debug": "4.3.4"
+                "debug": "4.3.7"
             },
             "engines": {
                 "node": ">=12"
@@ -8441,33 +8353,14 @@
                 "url": "https://opencollective.com/verdaccio"
             }
         },
-        "node_modules/@verdaccio/logger-commons/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@verdaccio/logger-prettify": {
-            "version": "7.0.0-next-7.3",
-            "resolved": "https://registry.npmjs.org/@verdaccio/logger-prettify/-/logger-prettify-7.0.0-next-7.3.tgz",
-            "integrity": "sha512-xPes4BuxEl1MUvDlYWO8oM3jcO3718p+ub7kx4kEGB48nTjF4wICkf/XdERj+cusE1dCodRWByNt9Hu32ER/JA==",
+            "version": "8.0.0-next-8.0",
+            "resolved": "https://registry.npmjs.org/@verdaccio/logger-prettify/-/logger-prettify-8.0.0-next-8.0.tgz",
+            "integrity": "sha512-7mAFHZF2NPTubrOXYp2+fbMjRW5MMWXMeS3LcpupMAn5uPp6jkKEM8NC4IVJEevC5Ph4vPVZqpoPDpgXHEaV3Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "colorette": "2.0.20",
-                "dayjs": "1.11.10",
+                "dayjs": "1.11.13",
                 "lodash": "4.17.21",
                 "pino-abstract-transport": "1.1.0",
                 "sonic-boom": "3.8.0"
@@ -8481,18 +8374,17 @@
             }
         },
         "node_modules/@verdaccio/middleware": {
-            "version": "7.0.0-next-7.20",
-            "resolved": "https://registry.npmjs.org/@verdaccio/middleware/-/middleware-7.0.0-next-7.20.tgz",
-            "integrity": "sha512-bY5/SuH0Oi3N7OSwuyG4uv4uHuV4LDzlDtbTucf7rN5Anok1Z5iXKsEk7p7m2r0M/J1QaMOggeN5tR8pEu0dQg==",
+            "version": "8.0.0-next-8.1",
+            "resolved": "https://registry.npmjs.org/@verdaccio/middleware/-/middleware-8.0.0-next-8.1.tgz",
+            "integrity": "sha512-GpAdJYky1WmOERpxPoCkVSwTTJIsVAjqf2a2uQNvi7R3UZhs059JKhWcZjJMVCGV0uz9xgQvtb3DEuYGHqyaOg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@verdaccio/config": "7.0.0-next-7.20",
-                "@verdaccio/core": "7.0.0-next-7.20",
-                "@verdaccio/url": "12.0.0-next-7.20",
-                "@verdaccio/utils": "7.0.0-next-7.20",
-                "debug": "4.3.4",
-                "express": "4.19.2",
+                "@verdaccio/config": "8.0.0-next-8.1",
+                "@verdaccio/core": "8.0.0-next-8.1",
+                "@verdaccio/url": "13.0.0-next-8.1",
+                "@verdaccio/utils": "7.0.1-next-8.1",
+                "debug": "4.3.7",
+                "express": "4.21.0",
                 "express-rate-limit": "5.5.1",
                 "lodash": "4.17.21",
                 "lru-cache": "7.18.3",
@@ -8506,30 +8398,11 @@
                 "url": "https://opencollective.com/verdaccio"
             }
         },
-        "node_modules/@verdaccio/middleware/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@verdaccio/middleware/node_modules/lru-cache": {
             "version": "7.18.3",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
             "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
             "dev": true,
-            "license": "ISC",
             "engines": {
                 "node": ">=12"
             }
@@ -8539,7 +8412,6 @@
             "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
             "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
             "dev": true,
-            "license": "MIT",
             "bin": {
                 "mime": "cli.js"
             },
@@ -8548,11 +8420,10 @@
             }
         },
         "node_modules/@verdaccio/search-indexer": {
-            "version": "7.0.0-next-7.2",
-            "resolved": "https://registry.npmjs.org/@verdaccio/search-indexer/-/search-indexer-7.0.0-next-7.2.tgz",
-            "integrity": "sha512-ZkhqHHWP530dFr8EuicAa5sXFDlAYqiSgpNDPIyMaz1FkfqngeffhWdydXQgVb60d1OeJkpaf3utPE2kQwIXxQ==",
+            "version": "8.0.0-next-8.0",
+            "resolved": "https://registry.npmjs.org/@verdaccio/search-indexer/-/search-indexer-8.0.0-next-8.0.tgz",
+            "integrity": "sha512-VS9axVt8XAueiPceVCgaj9nlvYj5s/T4MkAILSf2rVZeFFOMUyxU3mddUCajSHzL+YpqCuzLLL9865sRRzOJ9w==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=12"
             },
@@ -8562,13 +8433,12 @@
             }
         },
         "node_modules/@verdaccio/signature": {
-            "version": "7.0.0-next-7.5",
-            "resolved": "https://registry.npmjs.org/@verdaccio/signature/-/signature-7.0.0-next-7.5.tgz",
-            "integrity": "sha512-xF0xGi10HOAQ7Mkwf6dC2fjaBrdxxqXE/HMh/l/O5/LpWoGFZ6xsm/3ZieVRJtIq/qvL5pmmO5Tn8lPS7pm5SQ==",
+            "version": "8.0.0-next-8.0",
+            "resolved": "https://registry.npmjs.org/@verdaccio/signature/-/signature-8.0.0-next-8.0.tgz",
+            "integrity": "sha512-klcc2UlCvQxXDV65Qewo2rZOfv7S1y8NekS/8uurSaCTjU35T+fz+Pbqz1S9XK9oQlMp4vCQ7w3iMPWQbvphEQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "debug": "4.3.4",
+                "debug": "4.3.7",
                 "jsonwebtoken": "9.0.2"
             },
             "engines": {
@@ -8577,24 +8447,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/verdaccio"
-            }
-        },
-        "node_modules/@verdaccio/signature/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
             }
         },
         "node_modules/@verdaccio/streams": {
@@ -8613,44 +8465,25 @@
             }
         },
         "node_modules/@verdaccio/tarball": {
-            "version": "12.0.0-next-7.20",
-            "resolved": "https://registry.npmjs.org/@verdaccio/tarball/-/tarball-12.0.0-next-7.20.tgz",
-            "integrity": "sha512-jdVQw1tvuXikagK3f61hdEhLWfzj5iVebscmYBmcW5w/6vYIKQuc2MHXkp2q0sLT7Laa4hgW/I4ht7iF87c1VA==",
+            "version": "13.0.0-next-8.1",
+            "resolved": "https://registry.npmjs.org/@verdaccio/tarball/-/tarball-13.0.0-next-8.1.tgz",
+            "integrity": "sha512-58uimU2Bqt9+s+9ixy7wK/nPCqbOXhhhr/MQjl+otIlsUhSeATndhFzEctz/W+4MhUDg0tUnE9HC2yeNHHAo1Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@verdaccio/core": "7.0.0-next-7.20",
-                "@verdaccio/url": "12.0.0-next-7.20",
-                "@verdaccio/utils": "7.0.0-next-7.20",
-                "debug": "4.3.4",
+                "@verdaccio/core": "8.0.0-next-8.1",
+                "@verdaccio/url": "13.0.0-next-8.1",
+                "@verdaccio/utils": "7.0.1-next-8.1",
+                "debug": "4.3.7",
                 "gunzip-maybe": "^1.4.2",
                 "lodash": "4.17.21",
                 "tar-stream": "^3.1.7"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=14"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/verdaccio"
-            }
-        },
-        "node_modules/@verdaccio/tarball/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
             }
         },
         "node_modules/@verdaccio/tarball/node_modules/tar-stream": {
@@ -8658,7 +8491,6 @@
             "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
             "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "b4a": "^1.6.4",
                 "fast-fifo": "^1.2.0",
@@ -8666,21 +8498,19 @@
             }
         },
         "node_modules/@verdaccio/ui-theme": {
-            "version": "7.0.0-next-7.20",
-            "resolved": "https://registry.npmjs.org/@verdaccio/ui-theme/-/ui-theme-7.0.0-next-7.20.tgz",
-            "integrity": "sha512-97io/t49NtLWnm4RIk+b1d12ezC7ZGeorsDyyo+xeQNbYGEIX+FyRZlv8/eOGkHL1TvDYe6viOpgqLNz36Fj2g==",
-            "dev": true,
-            "license": "MIT"
+            "version": "8.0.0-next-8.1",
+            "resolved": "https://registry.npmjs.org/@verdaccio/ui-theme/-/ui-theme-8.0.0-next-8.1.tgz",
+            "integrity": "sha512-9PxV8+jE2Tr+iy9DQW/bzny4YqOlW0mCZ9ct6jhcUW4GdfzU//gY2fBN/DDtQVmfbTy8smuj4Enyv5f0wCsnYg==",
+            "dev": true
         },
         "node_modules/@verdaccio/url": {
-            "version": "12.0.0-next-7.20",
-            "resolved": "https://registry.npmjs.org/@verdaccio/url/-/url-12.0.0-next-7.20.tgz",
-            "integrity": "sha512-GtSM2A6nVjrFRxe0rrSWvQr4SCIZ+1ZA0blf7xeOV5+qFcy6MFjEhTY2jw+E0xYMq3mB78SxzH5tt7MA78v5Uw==",
+            "version": "13.0.0-next-8.1",
+            "resolved": "https://registry.npmjs.org/@verdaccio/url/-/url-13.0.0-next-8.1.tgz",
+            "integrity": "sha512-h6pkJf+YtogImKgOrmPP9UVG3p3gtb67gqkQU0bZnK+SEKQt6Rkek/QvtJ8MbmciagYS18bDhpI8DxqLHjDfZQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@verdaccio/core": "7.0.0-next-7.20",
-                "debug": "4.3.4",
+                "@verdaccio/core": "8.0.0-next-8.1",
+                "debug": "4.3.7",
                 "lodash": "4.17.21",
                 "validator": "13.12.0"
             },
@@ -8692,32 +8522,13 @@
                 "url": "https://opencollective.com/verdaccio"
             }
         },
-        "node_modules/@verdaccio/url/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@verdaccio/utils": {
-            "version": "7.0.0-next-7.20",
-            "resolved": "https://registry.npmjs.org/@verdaccio/utils/-/utils-7.0.0-next-7.20.tgz",
-            "integrity": "sha512-XkVvqLb8ObIEnEiHxBgimnk/0+KqeRPrAFI6mdPMwfvgBoQJGHe/a/79OAcCy7FnMAVAEEgdM5ddxifGR7GkPA==",
+            "version": "7.0.1-next-8.1",
+            "resolved": "https://registry.npmjs.org/@verdaccio/utils/-/utils-7.0.1-next-8.1.tgz",
+            "integrity": "sha512-cyJdRrVa+8CS7UuIQb3K3IJFjMe64v38tYiBnohSmhRbX7dX9IT3jWbjrwkqWh4KeS1CS6BYENrGG1evJ2ggrQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@verdaccio/core": "7.0.0-next-7.20",
+                "@verdaccio/core": "8.0.0-next-8.1",
                 "lodash": "4.17.21",
                 "minimatch": "7.4.6",
                 "semver": "7.6.3"
@@ -8735,7 +8546,6 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
             "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
             },
@@ -9217,15 +9027,15 @@
             }
         },
         "node_modules/ajv": {
-            "version": "8.16.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.16.0.tgz",
-            "integrity": "sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==",
+            "version": "8.17.1",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "dev": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
                 "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2",
-                "uri-js": "^4.4.1"
+                "require-from-string": "^2.0.2"
             },
             "funding": {
                 "type": "github",
@@ -9360,7 +9170,6 @@
             "resolved": "https://registry.npmjs.org/apache-md5/-/apache-md5-1.1.8.tgz",
             "integrity": "sha512-FCAJojipPn0bXjuEpjOOOMN8FZDkxfWWp4JGN9mifU2IhxvKyXZYqpzPHdnTSUpmPDy+tsslB6Z1g+Vg6nVbYA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -9687,7 +9496,6 @@
             "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
             "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=8.0.0"
             }
@@ -9792,11 +9600,10 @@
             }
         },
         "node_modules/b4a": {
-            "version": "1.6.6",
-            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.6.tgz",
-            "integrity": "sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg==",
-            "dev": true,
-            "license": "Apache-2.0"
+            "version": "1.6.7",
+            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
+            "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
+            "dev": true
         },
         "node_modules/babel-core": {
             "version": "7.0.0-bridge.0",
@@ -10102,11 +9909,10 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
         },
         "node_modules/bare-events": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.4.2.tgz",
-            "integrity": "sha512-qMKFd2qG/36aA4GwvKq8MxnPgCQAmBWmSyLWsJcbn8v03wvIPQ/hG1Ms8bPzndZxMDoHpxez5VOS+gC9Yi24/Q==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.0.tgz",
+            "integrity": "sha512-/E8dDe9dsbLyh2qrZ64PEPadOQ0F4gbl1sUJOrmph7xOiIxfY8vwab/4bFLh4Y88/Hk/ujKcrQKc+ps0mv873A==",
             "dev": true,
-            "license": "Apache-2.0",
             "optional": true
         },
         "node_modules/base64-js": {
@@ -10167,8 +9973,7 @@
             "version": "2.4.3",
             "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
             "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/big.js": {
             "version": "5.2.2",
@@ -10511,9 +10316,9 @@
             "dev": true
         },
         "node_modules/body-parser": {
-            "version": "1.20.2",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-            "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+            "version": "1.20.3",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+            "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
             "dev": true,
             "dependencies": {
                 "bytes": "3.1.2",
@@ -10524,7 +10329,7 @@
                 "http-errors": "2.0.0",
                 "iconv-lite": "0.4.24",
                 "on-finished": "2.4.1",
-                "qs": "6.11.0",
+                "qs": "6.13.0",
                 "raw-body": "2.5.2",
                 "type-is": "~1.6.18",
                 "unpipe": "1.0.0"
@@ -10548,21 +10353,6 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
             "dev": true
-        },
-        "node_modules/body-parser/node_modules/qs": {
-            "version": "6.11.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-            "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
-            "dev": true,
-            "dependencies": {
-                "side-channel": "^1.0.4"
-            },
-            "engines": {
-                "node": ">=0.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
         },
         "node_modules/bonjour-service": {
             "version": "1.2.1",
@@ -10811,8 +10601,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
             "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-            "dev": true,
-            "license": "BSD-3-Clause"
+            "dev": true
         },
         "node_modules/buffer-from": {
             "version": "1.1.2",
@@ -12160,12 +11949,11 @@
             }
         },
         "node_modules/core-js": {
-            "version": "3.35.0",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.35.0.tgz",
-            "integrity": "sha512-ntakECeqg81KqMueeGJ79Q5ZgQNR+6eaE8sxGCx62zMbAIj65q+uYvatToew3m6eAGdU4gNZwpZ34NMe4GYswg==",
+            "version": "3.37.1",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.1.tgz",
+            "integrity": "sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==",
             "dev": true,
             "hasInstallScript": true,
-            "license": "MIT",
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/core-js"
@@ -12875,19 +12663,18 @@
             }
         },
         "node_modules/dayjs": {
-            "version": "1.11.10",
-            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
-            "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==",
-            "dev": true,
-            "license": "MIT"
+            "version": "1.11.13",
+            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+            "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+            "dev": true
         },
         "node_modules/debug": {
-            "version": "4.3.5",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
-            "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+            "version": "4.3.7",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+            "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
             "dev": true,
             "dependencies": {
-                "ms": "2.1.2"
+                "ms": "^2.1.3"
             },
             "engines": {
                 "node": ">=6.0"
@@ -12897,6 +12684,12 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/debug/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true
         },
         "node_modules/decamelize": {
             "version": "4.0.0",
@@ -13500,7 +13293,6 @@
             "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
             "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "end-of-stream": "^1.0.0",
                 "inherits": "^2.0.1",
@@ -13512,15 +13304,13 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/duplexify/node_modules/readable-stream": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
             "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -13535,15 +13325,13 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/duplexify/node_modules/string_decoder": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "safe-buffer": "~5.1.0"
             }
@@ -13569,7 +13357,6 @@
             "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
             "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
             "dev": true,
-            "license": "Apache-2.0",
             "dependencies": {
                 "safe-buffer": "^5.0.1"
             }
@@ -13655,9 +13442,9 @@
             "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
         },
         "node_modules/encodeurl": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-            "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+            "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
             "dev": true,
             "engines": {
                 "node": ">= 0.8"
@@ -15522,37 +15309,37 @@
             }
         },
         "node_modules/express": {
-            "version": "4.19.2",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
-            "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
+            "version": "4.21.0",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
+            "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
             "dev": true,
             "dependencies": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
-                "body-parser": "1.20.2",
+                "body-parser": "1.20.3",
                 "content-disposition": "0.5.4",
                 "content-type": "~1.0.4",
                 "cookie": "0.6.0",
                 "cookie-signature": "1.0.6",
                 "debug": "2.6.9",
                 "depd": "2.0.0",
-                "encodeurl": "~1.0.2",
+                "encodeurl": "~2.0.0",
                 "escape-html": "~1.0.3",
                 "etag": "~1.8.1",
-                "finalhandler": "1.2.0",
+                "finalhandler": "1.3.1",
                 "fresh": "0.5.2",
                 "http-errors": "2.0.0",
-                "merge-descriptors": "1.0.1",
+                "merge-descriptors": "1.0.3",
                 "methods": "~1.1.2",
                 "on-finished": "2.4.1",
                 "parseurl": "~1.3.3",
-                "path-to-regexp": "0.1.7",
+                "path-to-regexp": "0.1.10",
                 "proxy-addr": "~2.0.7",
-                "qs": "6.11.0",
+                "qs": "6.13.0",
                 "range-parser": "~1.2.1",
                 "safe-buffer": "5.2.1",
-                "send": "0.18.0",
-                "serve-static": "1.15.0",
+                "send": "0.19.0",
+                "serve-static": "1.16.2",
                 "setprototypeof": "1.2.0",
                 "statuses": "2.0.1",
                 "type-is": "~1.6.18",
@@ -15567,8 +15354,7 @@
             "version": "5.5.1",
             "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-5.5.1.tgz",
             "integrity": "sha512-MTjE2eIbHv5DyfuFz4zLYWxpqVhEhkTiwFGuB74Q9CSou2WHO52nlE5y3Zlg6SIsiYUIPj6ifFxnkPz6O3sIUg==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/express/node_modules/debug": {
             "version": "2.6.9",
@@ -15584,21 +15370,6 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
             "dev": true
-        },
-        "node_modules/express/node_modules/qs": {
-            "version": "6.11.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-            "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
-            "dev": true,
-            "dependencies": {
-                "side-channel": "^1.0.4"
-            },
-            "engines": {
-                "node": ">=0.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
         },
         "node_modules/ext-list": {
             "version": "2.2.2",
@@ -15684,8 +15455,7 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
             "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/fast-glob": {
             "version": "3.2.7",
@@ -15739,7 +15509,6 @@
             "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
             "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
@@ -15748,6 +15517,12 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
             "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+            "dev": true
+        },
+        "node_modules/fast-uri": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.2.tgz",
+            "integrity": "sha512-GR6f0hD7XXyNJa25Tb9BuIdN0tdr+0BMi6/CJPH3wJO1JjNG3n/VsSw38AwRdKZABm8lGbPfakLRkYzx2V9row==",
             "dev": true
         },
         "node_modules/fastq": {
@@ -16026,13 +15801,13 @@
             }
         },
         "node_modules/finalhandler": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-            "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+            "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
             "dev": true,
             "dependencies": {
                 "debug": "2.6.9",
-                "encodeurl": "~1.0.2",
+                "encodeurl": "~2.0.0",
                 "escape-html": "~1.0.3",
                 "on-finished": "2.4.1",
                 "parseurl": "~1.3.3",
@@ -16975,7 +16750,6 @@
             "resolved": "https://registry.npmjs.org/gunzip-maybe/-/gunzip-maybe-1.4.2.tgz",
             "integrity": "sha512-4haO1M4mLO91PW57BMsDFf75UmwoRX0GkdD+Faw+Lr+r/OZrOCS0pIBwOL1xCKQqnQzbNFGgK2V2CpBUPeFNTw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "browserify-zlib": "^0.1.4",
                 "is-deflate": "^1.0.0",
@@ -16993,7 +16767,6 @@
             "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
             "integrity": "sha512-19OEpq7vWgsH6WkvkBJQDFvJS1uPcbFOQ4v9CU839dO+ZZXUZO6XpE6hNCqvlIIj+4fZvRiJ6DsAQ382GwiyTQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "pako": "~0.2.0"
             }
@@ -17002,8 +16775,7 @@
             "version": "0.2.9",
             "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
             "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/handle-thing": {
             "version": "2.0.1",
@@ -17550,8 +17322,7 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
             "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/http2-wrapper": {
             "version": "1.0.3",
@@ -18116,8 +17887,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-deflate/-/is-deflate-1.0.0.tgz",
             "integrity": "sha512-YDoFpuZWu1VRXlsnlYMzKyVRITXj7Ej/V9gXQ2/pAe7X1J7M/RNOqaIYi6qUn+B7nGyB9pDXrv02dsB58d2ZAQ==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/is-docker": {
             "version": "2.2.1",
@@ -18203,7 +17973,6 @@
             "resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz",
             "integrity": "sha512-rcfALRIb1YewtnksfRIHGcIY93QnK8BIQ/2c9yDYcG/Y6+vRoJuTWBmmSEbyLLYtXm7q35pHOHbZFQBaLrhlWQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -20104,7 +19873,6 @@
             "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
             "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "jws": "^3.2.2",
                 "lodash.includes": "^4.3.0",
@@ -20159,7 +19927,6 @@
             "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
             "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "buffer-equal-constant-time": "1.0.1",
                 "ecdsa-sig-formatter": "1.0.11",
@@ -20171,7 +19938,6 @@
             "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
             "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "jwa": "^1.4.1",
                 "safe-buffer": "^5.0.1"
@@ -20508,8 +20274,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
             "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/lodash.isarguments": {
             "version": "3.1.0",
@@ -20522,22 +20287,19 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
             "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/lodash.isinteger": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
             "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/lodash.isnumber": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
             "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/lodash.isplainobject": {
             "version": "4.0.6",
@@ -20549,8 +20311,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
             "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/lodash.kebabcase": {
             "version": "4.1.1",
@@ -20586,8 +20347,7 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
             "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/lodash.snakecase": {
             "version": "4.1.1",
@@ -20847,10 +20607,13 @@
             "dev": true
         },
         "node_modules/merge-descriptors": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-            "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
-            "dev": true
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+            "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/merge-stream": {
             "version": "2.0.0",
@@ -21443,7 +21206,6 @@
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
             "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "whatwg-url": "^5.0.0"
             },
@@ -21471,22 +21233,19 @@
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/node-fetch/node_modules/webidl-conversions": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
             "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-            "dev": true,
-            "license": "BSD-2-Clause"
+            "dev": true
         },
         "node_modules/node-fetch/node_modules/whatwg-url": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
             "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "tr46": "~0.0.3",
                 "webidl-conversions": "^3.0.0"
@@ -21908,7 +21667,6 @@
             "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
             "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -22317,9 +22075,9 @@
             "dev": true
         },
         "node_modules/path-to-regexp": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-            "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
+            "version": "0.1.10",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
+            "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
             "dev": true
         },
         "node_modules/path-type": {
@@ -22383,7 +22141,6 @@
             "resolved": "https://registry.npmjs.org/peek-stream/-/peek-stream-1.1.3.tgz",
             "integrity": "sha512-FhJ+YbOSBb9/rIl2ZeE/QHEsWn7PqNYt8ARAY3kIgNGOk13g9FGyIY6JIl/xB/3TFRVoTv5as0l11weORrTekA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "buffer-from": "^1.0.0",
                 "duplexify": "^3.5.0",
@@ -22428,7 +22185,6 @@
             "resolved": "https://registry.npmjs.org/pino/-/pino-8.17.2.tgz",
             "integrity": "sha512-LA6qKgeDMLr2ux2y/YiUt47EfgQ+S9LznBWOJdN3q1dx2sv0ziDLUBeVpyVv17TEcGCBuWf0zNtg3M5m1NhhWQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "atomic-sleep": "^1.0.0",
                 "fast-redact": "^3.1.1",
@@ -22451,7 +22207,6 @@
             "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.1.0.tgz",
             "integrity": "sha512-lsleG3/2a/JIWUtf9Q5gUNErBqwIu1tUKTT3dUzaf5DySw9ra1wcqKjJjLX1VTY64Wk1eEOYsVGSaGfCK85ekA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "readable-stream": "^4.0.0",
                 "split2": "^4.0.0"
@@ -22461,15 +22216,13 @@
             "version": "6.2.2",
             "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
             "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/pino/node_modules/process-warning": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
             "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/pirates": {
             "version": "4.0.6",
@@ -23366,8 +23119,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
             "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/prompts": {
             "version": "2.4.2",
@@ -23471,7 +23223,6 @@
             "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
             "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "duplexify": "^3.6.0",
                 "inherits": "^2.0.3",
@@ -23483,7 +23234,6 @@
             "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
             "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -23515,9 +23265,9 @@
             ]
         },
         "node_modules/qs": {
-            "version": "6.12.1",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.1.tgz",
-            "integrity": "sha512-zWmv4RSuB9r2mYQw3zxQuHWeU+42aKi1wWig/j4ele4ygELZ7PEO6MM7rim9oAQH2A5MWfsAVf/jPvTPgCbvUQ==",
+            "version": "6.13.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+            "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
             "dev": true,
             "dependencies": {
                 "side-channel": "^1.0.6"
@@ -23576,15 +23326,13 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
             "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/quick-format-unescaped": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
             "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/quick-lru": {
             "version": "5.1.1",
@@ -23951,7 +23699,6 @@
             "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
             "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 12.13.0"
             }
@@ -24782,9 +24529,9 @@
             }
         },
         "node_modules/send": {
-            "version": "0.18.0",
-            "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-            "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+            "version": "0.19.0",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+            "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
             "dev": true,
             "dependencies": {
                 "debug": "2.6.9",
@@ -24819,6 +24566,15 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
             "dev": true
+        },
+        "node_modules/send/node_modules/encodeurl": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+            "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.8"
+            }
         },
         "node_modules/send/node_modules/ms": {
             "version": "2.1.3",
@@ -24924,15 +24680,15 @@
             }
         },
         "node_modules/serve-static": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-            "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+            "version": "1.16.2",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+            "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
             "dev": true,
             "dependencies": {
-                "encodeurl": "~1.0.2",
+                "encodeurl": "~2.0.0",
                 "escape-html": "~1.0.3",
                 "parseurl": "~1.3.3",
-                "send": "0.18.0"
+                "send": "0.19.0"
             },
             "engines": {
                 "node": ">= 0.8.0"
@@ -25164,7 +24920,6 @@
             "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.0.tgz",
             "integrity": "sha512-ybz6OYOUjoQQCQ/i4LU8kaToD8ACtYP+Cj5qd2AO36bwbdewxWJ3ArmJ2cr6AvxlL2o0PqnCcPGUgkILbfkaCA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "atomic-sleep": "^1.0.0"
             }
@@ -25851,8 +25606,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
             "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/streamsearch": {
             "version": "1.1.0",
@@ -25865,11 +25619,10 @@
             }
         },
         "node_modules/streamx": {
-            "version": "2.18.0",
-            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.18.0.tgz",
-            "integrity": "sha512-LLUC1TWdjVdn1weXGcSxyTR3T4+acB6tVGXT95y0nGbca4t4o/ng1wKAGTljm9VicuCVLvRlqFYXYy5GwgM7sQ==",
+            "version": "2.20.1",
+            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.20.1.tgz",
+            "integrity": "sha512-uTa0mU6WUC65iUvzKH4X9hEdvSW7rbPxPtwfWiLMSj3qTdQbAiUboZTxauKfpFuGIGa1C2BYijZ7wgdUXICJhA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "fast-fifo": "^1.3.2",
                 "queue-tick": "^1.0.1",
@@ -26785,11 +26538,10 @@
             }
         },
         "node_modules/text-decoder": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.1.1.tgz",
-            "integrity": "sha512-8zll7REEv4GDD3x4/0pW+ppIxSNs7H1J10IKFZsuOMscumCdM2a+toDGLPA3T+1+fLBql4zbt5z83GEQGGV5VA==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.0.tgz",
+            "integrity": "sha512-n1yg1mOj9DNpk3NeZOx7T6jchTbyJS3i3cucbNN6FcdPriMZx7NsgrGpWWdWZZGxD7ES1XB+3uoqHMgOKaN+fg==",
             "dev": true,
-            "license": "Apache-2.0",
             "dependencies": {
                 "b4a": "^1.6.4"
             }
@@ -26822,7 +26574,6 @@
             "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.7.0.tgz",
             "integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "real-require": "^0.2.0"
             }
@@ -26838,7 +26589,6 @@
             "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
             "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "readable-stream": "~2.3.6",
                 "xtend": "~4.0.1"
@@ -26848,15 +26598,13 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/through2/node_modules/readable-stream": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
             "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -26871,15 +26619,13 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true,
-            "license": "MIT"
+            "dev": true
         },
         "node_modules/through2/node_modules/string_decoder": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "safe-buffer": "~5.1.0"
             }
@@ -27594,8 +27340,7 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/unix-crypt-td-js/-/unix-crypt-td-js-1.1.4.tgz",
             "integrity": "sha512-8rMeVYWSIyccIJscb9NdCfZKSRBKYTeVnwmiRYT2ulE3qd1RaDQ0xQDP+rI3ccIWbhu/zuo5cgN8z73belNZgw==",
-            "dev": true,
-            "license": "BSD-3-Clause"
+            "dev": true
         },
         "node_modules/unpipe": {
             "version": "1.0.0",
@@ -27780,7 +27525,6 @@
             "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
             "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">= 0.10"
             }
@@ -27795,33 +27539,32 @@
             }
         },
         "node_modules/verdaccio": {
-            "version": "5.32.1",
-            "resolved": "https://registry.npmjs.org/verdaccio/-/verdaccio-5.32.1.tgz",
-            "integrity": "sha512-GU8a+van7cQzzv6/pXWW8jMlQ7OoWNYPqRpvCW7F2QmxzpKp9hWb3yX9iLY3CJNrODuQYnUDjJ/hmBa8rUq+Aw==",
+            "version": "5.32.2",
+            "resolved": "https://registry.npmjs.org/verdaccio/-/verdaccio-5.32.2.tgz",
+            "integrity": "sha512-QnVYIUvwB884fwVcA/D+x7AabsRPlTPyYAKMtExm8kJjiH+s2LGK2qX2o3I4VmYXqBR3W9b8gEnyQnGwQhUPsw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@cypress/request": "3.0.1",
-                "@verdaccio/auth": "7.0.0-next-7.20",
-                "@verdaccio/config": "7.0.0-next-7.20",
-                "@verdaccio/core": "7.0.0-next-7.20",
+                "@verdaccio/auth": "8.0.0-next-8.1",
+                "@verdaccio/config": "8.0.0-next-8.1",
+                "@verdaccio/core": "8.0.0-next-8.1",
                 "@verdaccio/local-storage-legacy": "11.0.2",
-                "@verdaccio/logger-7": "7.0.0-next-7.20",
-                "@verdaccio/middleware": "7.0.0-next-7.20",
-                "@verdaccio/search-indexer": "7.0.0-next-7.2",
-                "@verdaccio/signature": "7.0.0-next-7.5",
+                "@verdaccio/logger-7": "8.0.0-next-8.1",
+                "@verdaccio/middleware": "8.0.0-next-8.1",
+                "@verdaccio/search-indexer": "8.0.0-next-8.0",
+                "@verdaccio/signature": "8.0.0-next-8.0",
                 "@verdaccio/streams": "10.2.1",
-                "@verdaccio/tarball": "12.0.0-next-7.20",
-                "@verdaccio/ui-theme": "7.0.0-next-7.20",
-                "@verdaccio/url": "12.0.0-next-7.20",
-                "@verdaccio/utils": "7.0.0-next-7.20",
+                "@verdaccio/tarball": "13.0.0-next-8.1",
+                "@verdaccio/ui-theme": "8.0.0-next-8.1",
+                "@verdaccio/url": "13.0.0-next-8.1",
+                "@verdaccio/utils": "7.0.1-next-8.1",
                 "async": "3.2.5",
                 "clipanion": "4.0.0-rc.3",
                 "compression": "1.7.4",
                 "cors": "2.8.5",
                 "debug": "^4.3.5",
                 "envinfo": "7.13.0",
-                "express": "4.19.2",
+                "express": "4.21.0",
                 "express-rate-limit": "5.5.1",
                 "fast-safe-stringify": "2.1.1",
                 "handlebars": "4.7.8",
@@ -27837,8 +27580,8 @@
                 "pkginfo": "0.4.1",
                 "semver": "7.6.3",
                 "validator": "13.12.0",
-                "verdaccio-audit": "12.0.0-next-7.20",
-                "verdaccio-htpasswd": "12.0.0-next-7.20"
+                "verdaccio-audit": "13.0.0-next-8.1",
+                "verdaccio-htpasswd": "13.0.0-next-8.1"
             },
             "bin": {
                 "verdaccio": "bin/verdaccio"
@@ -27852,15 +27595,14 @@
             }
         },
         "node_modules/verdaccio-audit": {
-            "version": "12.0.0-next-7.20",
-            "resolved": "https://registry.npmjs.org/verdaccio-audit/-/verdaccio-audit-12.0.0-next-7.20.tgz",
-            "integrity": "sha512-JlDM/G6i5aDrh6wYiN0NhPH+OnA8jF/74sWiyruHxdEd+yaJ0fkz1jeYtYPeFYNCfmM9TyJOUsxodS4KKO5W8w==",
+            "version": "13.0.0-next-8.1",
+            "resolved": "https://registry.npmjs.org/verdaccio-audit/-/verdaccio-audit-13.0.0-next-8.1.tgz",
+            "integrity": "sha512-EEfUeC1kHuErtwF9FC670W+EXHhcl+iuigONkcprwRfkPxmdBs+Hx36745hgAMZ9SCqedNECaycnGF3tZ3VYfw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@verdaccio/config": "7.0.0-next-7.20",
-                "@verdaccio/core": "7.0.0-next-7.20",
-                "express": "4.19.2",
+                "@verdaccio/config": "8.0.0-next-8.1",
+                "@verdaccio/core": "8.0.0-next-8.1",
+                "express": "4.21.0",
                 "https-proxy-agent": "5.0.1",
                 "node-fetch": "cjs"
             },
@@ -27873,18 +27615,17 @@
             }
         },
         "node_modules/verdaccio-htpasswd": {
-            "version": "12.0.0-next-7.20",
-            "resolved": "https://registry.npmjs.org/verdaccio-htpasswd/-/verdaccio-htpasswd-12.0.0-next-7.20.tgz",
-            "integrity": "sha512-YOP2SIMBKTbSYkBgMNHIgQxYn2wtMAZgV1EV0qTCR6Bnz4Z5euoxrDUXOBOf+QtaqsYViNZ6j8bOt+DZao6Fdw==",
+            "version": "13.0.0-next-8.1",
+            "resolved": "https://registry.npmjs.org/verdaccio-htpasswd/-/verdaccio-htpasswd-13.0.0-next-8.1.tgz",
+            "integrity": "sha512-BfvmO+ZdbwfttOwrdTPD6Bccr1ZfZ9Tk/9wpXamxdWB/XPWlk3FtyGsvqCmxsInRLPhQ/FSk9c3zRCGvICTFYg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@verdaccio/core": "7.0.0-next-7.20",
-                "@verdaccio/file-locking": "12.0.0-next.1",
+                "@verdaccio/core": "8.0.0-next-8.1",
+                "@verdaccio/file-locking": "13.0.0-next-8.0",
                 "apache-md5": "1.1.8",
                 "bcryptjs": "2.4.3",
-                "core-js": "3.35.0",
-                "debug": "4.3.4",
+                "core-js": "3.37.1",
+                "debug": "4.3.7",
                 "http-errors": "2.0.0",
                 "unix-crypt-td-js": "1.1.4"
             },
@@ -27897,11 +27638,10 @@
             }
         },
         "node_modules/verdaccio-htpasswd/node_modules/@verdaccio/file-locking": {
-            "version": "12.0.0-next.1",
-            "resolved": "https://registry.npmjs.org/@verdaccio/file-locking/-/file-locking-12.0.0-next.1.tgz",
-            "integrity": "sha512-Zb5G2HEhVRB0jCq4z7QA4dqTdRv/2kIsw2Nkm3j2HqC1OeJRxas3MJAF/OxzbAb1IN32lbg1zycMSk6NcbQkgQ==",
+            "version": "13.0.0-next-8.0",
+            "resolved": "https://registry.npmjs.org/@verdaccio/file-locking/-/file-locking-13.0.0-next-8.0.tgz",
+            "integrity": "sha512-28XRwpKiE3Z6KsnwE7o8dEM+zGWOT+Vef7RVJyUlG176JVDbGGip3HfCmFioE1a9BklLyGEFTu6D69BzfbRkzA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "lockfile": "1.0.4"
             },
@@ -27911,24 +27651,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/verdaccio"
-            }
-        },
-        "node_modules/verdaccio-htpasswd/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
             }
         },
         "node_modules/verdaccio/node_modules/kleur": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "ts-jest": "29.1.0",
         "ts-node": "10.9.1",
         "typescript": "~5.4.2",
-        "verdaccio": "^5.32.1"
+        "verdaccio": "^5.32.2"
     },
     "config": {
         "commitizen": {


### PR DESCRIPTION
#### 📲 What

Bump verdaccio from 5.32.1 → 5.32.2 to mitigate:

 - CVE-2024-45590 : body-parser vulnerable to denial of service when url encoding is enabled
 - Partial mitigation for CVE-2024-43796 : express vulnerable to XSS via response.redirect()
 - CVE-2024-43799 : send vulnerable to template injection that can lead to XSS
 - CVE-2024-43800 : serve-static vulnerable to template injection that can lead to XSS

##### Note

Unable to mitigate NextJS dependency without upgrading @nx/next and Nx 20 is due for release shortly.

```shell
 $ npm ls next
stacks-nx-plugins@0.0.0 /home/rslater/stacks/stacks-nx-plugins
├─┬ @nx/next@18.3.5
│ └── next@14.2.4
└─┬ @storybook/nextjs@8.2.9
  └── next@14.2.4 deduped
```

```shell
# npm audit report

next  14.0.0 - 14.2.9
Severity: high
Next.js Cache Poisoning - https://github.com/advisories/GHSA-gp8f-8m3g-qvj9
fix available via `npm audit fix`
node_modules/next

1 high severity vulnerability
```

#### 🤔 Why

We are committed to resolving Critical, High and Medium vulnerabilities within a reasonable timeframe within Stacks to meet our obligations under ISO 27001, CyberEssentials Plus and numerous commitments to clients.

#### 🛠 How

Updated verdaccio from 5.32.1 → 5.32.2 with `npm install verdaccio@5.32.2.

#### 👀 Evidence

```
   ✔  nx run common-test:lint (3s)
   ✔  nx run common-core:lint (5s)
   ✔  nx run playwright:lint (5s)
   ✔  nx run workspace:lint (3s)
   ✔  nx run create:lint (3s)
   ✔  nx run cypress:lint (3s)
   ✔  nx run common-e2e:lint (2s)
   ✔  nx run azure-react:lint (2s)
   ✔  nx run rest-client:lint (3s)
   ✔  nx run next:lint (3s)
   ✔  nx run azure-node:lint (3s)
   ✔  nx run logger:lint (3s)
```

#### 🕵️ How to test

```
nvm use 22.1.0
npm install -g npm@10.7.0
npm install
npm test
```

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [x] Passing all automated tests, including a successful deployment?
- [X] Rebased/merged with latest changes from development and re-tested?
- [X] Meeting the Coding Standards?
